### PR TITLE
Lab update and version commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,45 @@ reproducible configuration but the job must also work in the default environment
 for reproducibility. An example of environment specific configuration would be
 creating symlinks in the data directory for sharing large datasets internal to
 a lab while also downloading the data when the symlink does not exist.
+
+## update
+The `cap update` command will upgrade the CAPTURE framework to the latest
+version.
+
+Definition:
+```
+cap update
+```
+Example:
+```
+$ cap update
+
+Switched to branch 'main'
+From https://github.com/lasseignelab/capture
+ * branch            main       -> FETCH_HEAD
+Already up-to-date.
+
+Already on 'main'
+From https://github.com/lasseignelab/project-template
+ * branch            main       -> FETCH_HEAD
+Already up-to-date.
+
+CAPTURE updated to version v0.0.3
+```
+
+## version
+The `cap version` command will display the currently installed version
+of CAPTURE.
+
+Definition:
+```
+cap version
+```
+Example:
+```
+$ cap version
+
+v0.0.3
+
+```
+

--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ A framework and command line interface (CLI) for computational science.
 curl -sSL https://raw.githubusercontent.com/lasseignelab/capture/refs/heads/main/install.sh | bash
 source ~/.bash_profile
 ```
-# Update
+# Update to the current version
 ```
-cd ~/bin/capture
-git pull
-git submodule update --init --recursive
+cap update
 ```
 # Usage
 The `cap` CLI provides commands to help with reproducible research.
@@ -228,17 +226,11 @@ Example:
 ```
 $ cap update
 
+
 Switched to branch 'main'
-From https://github.com/lasseignelab/capture
- * branch            main       -> FETCH_HEAD
 Already up-to-date.
 
-Already on 'main'
-From https://github.com/lasseignelab/project-template
- * branch            main       -> FETCH_HEAD
-Already up-to-date.
-
-CAPTURE updated to version v0.0.3
+CAPTURE updated to version v0.0.1.
 ```
 
 ## version

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -42,20 +42,17 @@ cap_update() {
   echo
 
   # Retrieve the current version of the CAPTURE framework.
-  cd "$cap_install_dir"
+  if ! cd "$cap_install_dir"; then
+    echo "CAPTURE install directory is missing." >&2
+    exit 1
+  fi
   git checkout main
-  git pull origin main
-
-  # Retrieve the current project template for `cap new`.
-  echo
-  cd project-template
-  git checkout main
-  git pull origin main
+  git pull
+  git submodule update --init --recursive
 
   echo
 
   # Display the current version of CAPTURE.
-  cd ..
   if current_tag=$(git describe --tags --abbrev=0 2>/dev/null); then
     echo "CAPTURE updated to version $current_tag."
   else

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -21,16 +21,9 @@ cap_update_help() {
     $ cap update
 
     Switched to branch 'main'
-    From https://github.com/lasseignelab/capture
-     * branch            main       -> FETCH_HEAD
     Already up-to-date.
 
-    Already on 'main'
-    From https://github.com/lasseignelab/project-template
-     * branch            main       -> FETCH_HEAD
-    Already up-to-date.
-
-    CAPTURE updated to version v0.0.3.
+    CAPTURE updated to version v0.0.1.
 EOF
 }
 

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+cap_update_description() {
+  cat <<EOF
+  Updates the CAPTURE framework to the latest version.
+EOF
+}
+
+cap_update_help() {
+  cap_update_description
+  echo
+
+  cat <<EOF
+  The "update" command updates CAPTURE to the latest version with all the
+  newest features.
+
+  Usage:
+    cap update
+
+  Example:
+    $ cap update
+    CAPTURE updated to version v0.0.3.
+EOF
+}
+
+cap_update() {
+  # Location where the CAPTURE framework was installed.
+  cap_install_path=$(command -v cap)
+  cap_install_dir=$(dirname "$cap_install_path")
+
+  echo
+
+  # Retrieve the current version of the CAPTURE framework.
+  cd "$cap_install_dir"
+  git checkout main
+  git pull origin main
+
+  # Retrieve the current project template for `cap new`.
+  echo
+  cd project-template
+  git checkout main
+  git pull origin main
+
+  echo
+
+  # Display the current version of CAPTURE.
+  cd ..
+  if current_tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+    echo "CAPTURE updated to version $current_tag."
+  else
+    echo "CAPTURE updated to an unlabeled version."
+  fi
+
+  echo
+}

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -19,6 +19,17 @@ cap_update_help() {
 
   Example:
     $ cap update
+
+    Switched to branch 'main'
+    From https://github.com/lasseignelab/capture
+     * branch            main       -> FETCH_HEAD
+    Already up-to-date.
+
+    Already on 'main'
+    From https://github.com/lasseignelab/project-template
+     * branch            main       -> FETCH_HEAD
+    Already up-to-date.
+
     CAPTURE updated to version v0.0.3.
 EOF
 }

--- a/commands/version.sh
+++ b/commands/version.sh
@@ -30,7 +30,10 @@ cap_version() {
   echo
 
   # Display the current version of CAPTURE.
-  cd "$cap_install_dir"
+  if ! cd "$cap_install_dir"; then
+    echo "CAPTURE install directory is missing." >&2
+    exit 1
+  fi
   if current_tag=$(git describe --tags --abbrev=0 2>/dev/null); then
     echo "$current_tag"
   else

--- a/commands/version.sh
+++ b/commands/version.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+cap_version_description() {
+  cat <<EOF
+  Displays the currently installed version of CAPTURE.
+EOF
+}
+
+cap_version_help() {
+  cap_version_description
+  echo
+
+  cat <<EOF
+  The "version" command displays the current version of the CAPTURE framework.
+
+  Usage:
+    cap version
+
+  Example:
+    $ cap version
+    v0.0.3
+EOF
+}
+
+cap_version() {
+  # Location where the CAPTURE framework was installed.
+  cap_install_path=$(command -v cap)
+  cap_install_dir=$(dirname "$cap_install_path")
+
+  echo
+
+  # Display the current version of CAPTURE.
+  cd "$cap_install_dir"
+  if current_tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+    echo "$current_tag"
+  else
+    echo "Unlabeled version."
+  fi
+
+  echo
+}
+


### PR DESCRIPTION
The update command will upgrade the version of CAPTURE and the project template by pulling the most recent version from the main branch.

The version command displays the current CAPTURE version installed in the user's environment.

### Testing instructions

Setup:
```
cd ~/bin/capture
git checkout main
git pull
git checkout lab-update
git submodule update --init --recursive

```
Test `cap version`:
The current version should be v0.0.1.
```
cap version

```
It works if `v0.0.1` is displayed.

Test `cap update`:
This will be weird because the currently released version does not have the `cap update` and `cap version` commands which means they will no longer be available after the update.  To run them again, the setup instructions above will need to be ran again.
```
cap update

```
`cap update` works if the update and version commands are no longer listed when the `cap help` command is run.
```
cap help

```