### PR TITLE
Add cap env command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,27 @@ The `cap` CLI provides commands to help with reproducible research.
 ```
 cap <command> params...
 ```
+## env
+Displays CAPTURE environment variables.
+
+Definition:
+```
+cap env
+```
+Example:
+```
+$ cap env
+
+CAP_CONDA_PATH=/data/user/acrumley/3xtg-repurposing/bin/conda
+CAP_CONTAINER_PATH=/data/user/acrumley/3xtg-repurposing/bin/docker
+CAP_DATA_PATH=/data/user/acrumley/3xtg-repurposing/data
+CAP_ENV=default
+CAP_LOGS_PATH=/data/user/acrumley/3xtg-repurposing/logs
+CAP_PROJECT_NAME=3xtg-repurposing
+CAP_PROJECT_PATH=/data/user/acrumley/3xtg-repurposing
+CAP_RANDOM_SEED=16600
+CAP_RESULTS_PATH=/data/user/acrumley/3xtg-repurposing/results
+```
 
 ## help
 Shows help for the cap command line tool.

--- a/cap
+++ b/cap
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-# Resolve the directory of the script
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+# Location where the CAPTURE framework was installed.
+cap_install_fullpath=$(command -v cap)
+CAP_INSTALL_PATH=$(dirname "$cap_install_fullpath")
 
 # Load commands
-for file in "$SCRIPT_DIR"/commands/*.sh; do
+for file in "$CAP_INSTALL_PATH"/commands/*.sh; do
     source "$file"
 done
 

--- a/commands/env.sh
+++ b/commands/env.sh
@@ -35,7 +35,7 @@ EOF
 }
 
 cap_env() {
-  # Location where the CAPTURE framework was installed.
+  # Load the CAPTURE environment.
   source "$CAP_INSTALL_PATH/lib/environment.sh"
 
   # Display CAPTURE environment variables.

--- a/commands/env.sh
+++ b/commands/env.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+cap_env_description() {
+  cat <<EOF
+  Displays CAPTURE environment variables.
+EOF
+}
+
+cap_env_help() {
+  cap_env_description
+  echo
+
+  cat <<EOF
+  The "env" command displays a list of all the CAPTURE environment variables
+  along with their values. File and path values are displayed with full
+  paths.
+
+  Usage:
+    cap env
+
+  Example:
+    $ cap env
+
+    CAP_CONDA_PATH=/data/user/acrumley/3xtg-repurposing/bin/conda
+    CAP_CONTAINER_PATH=/data/user/acrumley/3xtg-repurposing/bin/docker
+    CAP_DATA_PATH=/data/user/acrumley/3xtg-repurposing/data
+    CAP_ENV=default
+    CAP_LOGS_PATH=/data/user/acrumley/3xtg-repurposing/logs
+    CAP_PROJECT_NAME=3xtg-repurposing
+    CAP_PROJECT_PATH=/data/user/acrumley/3xtg-repurposing
+    CAP_RANDOM_SEED=16600
+    CAP_RESULTS_PATH=/data/user/acrumley/3xtg-repurposing/results
+
+EOF
+}
+
+cap_env() {
+  # Location where the CAPTURE framework was installed.
+  source "$CAP_INSTALL_PATH/lib/environment.sh"
+
+  # Display CAPTURE environment variables.
+  echo
+  env | grep -E "^CAP" | sort
+  echo
+}

--- a/commands/help.sh
+++ b/commands/help.sh
@@ -46,11 +46,11 @@ cap_help() {
 EOF
 
     # Directory containing the scripts
-    COMMANDS_DIR="$SCRIPT_DIR"/commands
+    CAP_COMMANDS_DIR="$CAP_INSTALL_PATH"/commands
 
     {
       # Loop through each script file in the directory
-      for script in "$COMMANDS_DIR"/*.sh; do
+      for script in "$CAP_COMMANDS_DIR"/*.sh; do
         # Get the base name of the script (e.g., md5 for md5.sh)
         script_name=$(basename "$script" .sh)
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -54,15 +54,11 @@ cap_run() {
   slurm_header=$(grep "#SBATCH" "$job_file")
   slurm_code=$(grep -v -E "(^#\!)|(#SBATCH)" "$job_file")
 
-  # Location where the CAPTURE framework was installed.
-  cap_install_path=$(command -v cap)
-  cap_install_dir=$(dirname "$cap_install_path")
-
   # Put job back together with the framework function included.
   slurm_job=$(cat <<EOF
 $slurm_shebang
 $slurm_header
-source $cap_install_dir/lib/functions.sh
+source $CAP_INSTALL_PATH/lib/functions.sh
 $slurm_code
 EOF
 )
@@ -71,7 +67,7 @@ EOF
   if [ -n "$environment_override" ]; then
     CAP_ENV="$environment_override"
   fi
-  source "$cap_install_dir/lib/environment.sh"
+  source "$CAP_INSTALL_PATH/lib/environment.sh"
 
 
   # Specify the log file names with their full path. Log file names will
@@ -103,7 +99,7 @@ cap_run_dry_run() {
   echo "Environment: $CAP_ENV"
   echo
   # Display the framework environment variables.
-  env | grep -E "^CAP"
+  env | grep -E "^CAP" | sort
   echo
   echo "Job: $job_name"
   echo


### PR DESCRIPTION
The `cap env` command will display all the CAPTURE related environment variables for a project.

Setup:
```
cd ~/bin/capture
git checkout main
git pull
git checkout cap-env
git submodule update --init --recursive

```
Test:
Change to an existing or new project directory.
```
cap env
```
If it works correctly then a number of `CAP_` environment variables will be displayed with their values.  An example of the values can be seen in the `cap help env` help and the `cap env` documentation in the README.md