### PR TITLE
Cap data link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,19 @@ Example:
 ```
 $ cap help
 
-  Commands:
+  Usage: cap COMMAND ...
 
-  help  Shows help for the cap command line tool.
-  md5   Calculates a combined MD5 checksum for one or more files.
+  Commands:
+    The following subcommands are available.
+
+  COMMAND
+    env        Displays CAPTURE environment variables.
+    help       Shows help for the cap command line tool.
+    md5        Calculates a combined MD5 checksum for one or more files.
+    new        Creates a new reproducible research project.
+    run        Runs a CAPTURE framework job.
+    update     Updates the CAPTURE framework to the latest version.
+    version    Displays the currently installed version of CAPTURE.
 
 $ cap help md5
 
@@ -111,11 +120,23 @@ repository owner specified by the Github account and project name parameters.
 
 Definition:
 ```
-cap new GITHUB_OWNER PROJECT_NAME
+cap new [options] PROJECT_NAME
 
-GITHUB_OWNER Github owner the project repo will be created under.  This may
-             be a personal or organization account.
-PROJECT_NAME Name of the project which will match the Github repo name.
+PROJECT_NAME Name of the project which will be used for the directory name.
+			 It should also match the git host repo name if one is used.
+
+Options:
+
+--git-host=<host-domain-name>
+		   Git host for the repository used for creating git remotes.  The
+		   default is "github.com".
+-o,--owner=<owner-id>
+		   Git host owner the project repo will be created under.  This may
+		   be a personal or organization account.
+--skip-git
+		   Skip making the project a git repository in order to allow
+		   the use of other source control software.
+
 ```
 Example:
 ```

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ creating symlinks in the data directory for sharing large datasets internal to
 a lab while also downloading the data when the symlink does not exist.
 
 Environment set up functions for environment files, e.g. config/environments/*:
-- cap_data_link <FILE>|<DIR>: Creates a symbolic link in the CAP_DATA_PATH
+- `cap_data_link <FILE>|<DIR>`: Creates a symbolic link in the CAP_DATA_PATH
 directory to a file or directory.  The symbolic link will have the same name
 as the specified file or directory. The following example will create the link
 `$CAP_DATA_PATH/mouse`:

--- a/README.md
+++ b/README.md
@@ -256,6 +256,14 @@ for reproducibility. An example of environment specific configuration would be
 creating symlinks in the data directory for sharing large datasets internal to
 a lab while also downloading the data when the symlink does not exist.
 
+Environment set up functions for environment files, e.g. config/environments/*:
+- cap_data_link <FILE>|<DIR>: Creates a symbolic link in the CAP_DATA_PATH
+directory to a file or directory.  The symbolic link will have the same name
+as the specified file or directory. The following example will create the link
+`$CAP_DATA_PATH/mouse`:
+```
+cap_data_link "$MY_LAB/genome/mouse"
+```
 ## update
 The `cap update` command will upgrade the CAPTURE framework to the latest
 version.

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -28,14 +28,10 @@ EOF
 }
 
 cap_update() {
-  # Location where the CAPTURE framework was installed.
-  cap_install_path=$(command -v cap)
-  cap_install_dir=$(dirname "$cap_install_path")
-
   echo
 
   # Retrieve the current version of the CAPTURE framework.
-  if ! cd "$cap_install_dir"; then
+  if ! cd "$CAP_INSTALL_PATH"; then
     echo "CAPTURE install directory is missing." >&2
     exit 1
   fi

--- a/commands/version.sh
+++ b/commands/version.sh
@@ -23,14 +23,10 @@ EOF
 }
 
 cap_version() {
-  # Location where the CAPTURE framework was installed.
-  cap_install_path=$(command -v cap)
-  cap_install_dir=$(dirname "$cap_install_path")
-
   echo
 
   # Display the current version of CAPTURE.
-  if ! cd "$cap_install_dir"; then
+  if ! cd "$CAP_INSTALL_PATH"; then
     echo "CAPTURE install directory is missing." >&2
     exit 1
   fi

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -68,6 +68,7 @@ if [ -f "$CAP_PROJECT_PATH/.caprc" ]; then
   source "$CAP_PROJECT_PATH/.caprc"
 fi
 if [ -f "$CAP_PROJECT_PATH/config/environments/$CAP_ENV.sh" ]; then
+  source "$CAP_INSTALL_PATH/lib/environment_functions.sh"
   # shellcheck disable=SC1090
   source "$CAP_PROJECT_PATH/config/environments/$CAP_ENV.sh"
 fi

--- a/lib/environment_functions.sh
+++ b/lib/environment_functions.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+cap_data_link() {
+  # Verify the file/directory parameter has been passed in.
+  target_path="$1"
+  if [ -z "$target_path" ]; then
+    echo "Error cap_data_link: incorrect number of parameters" >&2
+    echo "Usage: cap_data_link <target_path>" >&2
+    echo "Check environment file config/environments/$CAP_ENV.sh." >&2
+    echo "See README for detailed help." >&2
+    exit 1
+  fi
+
+  # Verify that the file/directory exists.
+  if [ ! -e "$target_path" ]; then
+    echo "Error cap_data_link: File or directory does not exist." >&2
+    echo "Path: $target_path" >&2
+    echo "Check environment file config/environments/$CAP_ENV.sh." >&2
+    exit 1
+  fi
+
+  # Create a symlink to the file/directory in the project data path.
+  if [ ! -d "$CAP_DATA_PATH" ]; then
+    mkdir -p "$CAP_DATA_PATH"
+  fi
+  link_path="$CAP_DATA_PATH/$(basename "$target_path")"
+  if [ ! -e "$link_path" ]; then
+    ln -s "$target_path" "$link_path"
+  fi
+}


### PR DESCRIPTION
Add a function `cap_data_link <FILE>|<DIR>` for configuring symbolic links to internal lab data.  Scenarios where this is helpful are to save disk space by not having duplicate versions of large datasets and access to shared copies of unpublished lab data.

Set up for testing:
```
cd ~/bin/capture
git checkout main
git pull
git checkout cap-data-link

```

To test with a lasseignelab environment:

- Add a `~/.caprc` with the following contents:
```
#!/bin/bash

source "/data/project/lasseigne_lab/.caprc"
```

- In an existing or new project created by CAPTURE add the following to `config/environments/lasseignelab.sh
```
#!/bin/bash

cap_data_link "$LASSEIGNE_LAB_PATH/GENOME_dir/refdata-gex-GRCm39-2024-A"
```
- Create a job such as `src/01_testing.sh` with the following contents.
```
#!/bin/bash

#SBATCH --nodes=1
#SBATCH --ntasks=1
#SBATCH --mem-per-cpu=32G
#SABTCH --cpus-per-task=4
#SBATCH --time=5:00:00
#SBATCH --partition=medium

echo "Hello World!!"
```
- Make sure you don't already have the directory `data/refdata-gex-GRCm39-2024-A` from previous testing.
- Run the job you created like the following example.
```
cap run src/01_testing.sh

```
- Run the following commands.
```
ls data
ls data/refdata-gex-GRCm39-2024-A

```
- The output should look something like this.
```
$ ls data/
README  refdata-gex-GRCm39-2024-A 
$ ls data/refdata-gex-GRCm39-2024-A
fasta  genes  reference.json  star
```