### PR TITLE
Fix cap run environment override

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -64,10 +64,10 @@ EOF
 )
 
   # Setup the runtime environment for the job.
+  source "$CAP_INSTALL_PATH/lib/environment.sh"
   if [ -n "$environment_override" ]; then
     CAP_ENV="$environment_override"
   fi
-  source "$CAP_INSTALL_PATH/lib/environment.sh"
 
 
   # Specify the log file names with their full path. Log file names will


### PR DESCRIPTION
The cap run option -e,--environment did not work correctly when CAP_ENV was set in a caprc file because the override was happening before the environment was included.  This caused the override to get overridden by environment configuration.

To fix this problem, the override was moved after the environment configuration.

Setup for testing:
```
cd ~/bin/capture
git pull
git checkout lab-run-env-fix

```
Prepare for testing:
Create a `~/.caprc` file with the following:
```
#!/bin/bash

source "/data/project/lasseigne_lab/.caprc"
```
If you don't have a CAPTURE test project run the following in your projects folder:
```
cap new testing
```
Use an existing test file or create one like this in the src folder:
```
#!/bin/bash

#SBATCH --nodes=1
#SBATCH --ntasks=1
#SBATCH --mem-per-cpu=32G
#SABTCH --cpus-per-task=4
#SBATCH --time=5:00:00
#SBATCH --partition=medium

echo "Hello World!!"
```
Run the following command:
```
cap run -n src/<file-name>
```
The output should have `lasseignelab` as the environment and look something like this at the top:
```
Environment: lasseignelab

CAP_CONDA_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing/bin/conda
CAP_CONTAINER_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing/bin/docker
CAP_DATA_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing/data
CAP_ENV=lasseignelab
CAP_LOGS_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing/logs
CAP_PROJECT_NAME=3xtg-mice-ad-drug-repurposing
CAP_PROJECT_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing
CAP_RANDOM_SEED=16600
CAP_RESULTS_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing/results
```
Run the following command:
```
cap run -e default -n src/<file-name>
```
The output should have `default` as the environment and look something like this at the top:
```
Environment: default

CAP_CONDA_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing/bin/conda
CAP_CONTAINER_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing/bin/docker
CAP_DATA_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing/data
CAP_ENV=default
CAP_LOGS_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing/logs
CAP_PROJECT_NAME=3xtg-mice-ad-drug-repurposing
CAP_PROJECT_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing
CAP_RANDOM_SEED=16600
CAP_RESULTS_PATH=/data/user/acrumley/3xtg-mice-ad-drug-repurposing/results
```
To get back to the released version use the following command:
```
cap update
```