### PR TITLE
Add cap_data_download method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ source ~/.bash_profile
 ```
 cap update
 ```
-# Usage
+# CLI Usage
 The `cap` CLI provides commands to help with reproducible research.
 ```
 cap <command> params...
@@ -254,16 +254,9 @@ any Slurm environment. Other lab specific environment files can contain non-
 reproducible configuration but the job must also work in the default environment
 for reproducibility. An example of environment specific configuration would be
 creating symlinks in the data directory for sharing large datasets internal to
-a lab while also downloading the data when the symlink does not exist.
+a lab while also downloading the data when the symlink does not exist. See
+[cap_data_link](#cap_data_link).
 
-Environment set up functions for environment files, e.g. config/environments/*:
-- `cap_data_link <FILE>|<DIR>`: Creates a symbolic link in the CAP_DATA_PATH
-directory to a file or directory.  The symbolic link will have the same name
-as the specified file or directory. The following example will create the link
-`$CAP_DATA_PATH/mouse`:
-```
-cap_data_link "$MY_LAB/genome/mouse"
-```
 ## update
 The `cap update` command will upgrade the CAPTURE framework to the latest
 version.
@@ -298,4 +291,41 @@ $ cap version
 v0.0.3
 
 ```
+# Helper Functions
+## cap_data_download
+Downloads data into the data directory.
+```
+cap_data_download [options] URL
+```
+`URL` The URL of the file to download.
 
+Options
+- `--md5sum` The md5sum to check against the file being downloaded.
+
+The file will be downloaded with the same name as specified by the URL.  If the
+file is a TAR file then it will be unarchived into the data directory.  The
+data directory is specified by `CAP_DATA_PATH` which defaults to
+`CAP_PROJECT_PATH/data`.
+
+The following example and download and unarchive a directory into
+`CAP_DATA_PATH/refdata-gex-GRCm39-2024-A`.
+```
+cap_data_download \
+  --md5sum="37c51137ccaeabd4d151f80dc86ce0b3" \
+    "https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-GRCm39-2024-A.tar.gz"
+```
+## cap_data_link
+Creates a symbolic link in the data directory.
+```
+cap_data_link <FILE>|<DIR>
+```
+`<FILE>|<DIR>` The full path to a file or directory.
+
+The symbolic link will have the same name as the specified file or directory
+and will be created in the directory specified by `CAP_DATA_PATH` which
+defaults to `CAP_PROJECT_PATH/data`.
+
+The following example will create the symbolic link `$CAP_DATA_PATH/mouse`.
+```
+cap_data_link "$MY_LAB/genome/mouse"
+```

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ file is a TAR file then it will be unarchived into the data directory.  The
 data directory is specified by `CAP_DATA_PATH` which defaults to
 `CAP_PROJECT_PATH/data`.
 
-The following example and download and unarchive a directory into
+The following example will download and unarchive a directory into
 `CAP_DATA_PATH/refdata-gex-GRCm39-2024-A`.
 ```
 cap_data_download \

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ The following example will download and unarchive a directory into
 ```
 cap_data_download \
   --md5sum="37c51137ccaeabd4d151f80dc86ce0b3" \
-    "https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-GRCm39-2024-A.tar.gz"
+  "https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-GRCm39-2024-A.tar.gz"
 ```
 ## cap_data_link
 Creates a symbolic link in the data directory.

--- a/commands/new.sh
+++ b/commands/new.sh
@@ -178,7 +178,6 @@ EOF
 
 cap_new_parse_commandline_parameters() {
   # Define the named commandline options
-
   if ! OPTIONS=$(getopt -o o: --long owner:,git-host:,skip-git -- "$@"); then
     echo "Use the 'cap help new' command for detailed help."
     exit 1

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -88,7 +88,7 @@ EOF
     cap_run_dry_run
   else
     sbatch -D "$job_directory" \
-      --job-name="$CAP_PROJECT_NAME-${job_name%.*}" \
+      --job-name="${job_name%.*}-$CAP_PROJECT_NAME" \
       --output "$log_full_path/$log_file_name.out" \
       --error "$log_full_path/$log_file_name.err" \
       <<EOF

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -64,6 +64,9 @@ EOF
 )
 
   # Setup the runtime environment for the job.
+  if [ -n "$environment_override" ]; then
+    CAP_ENV="$environment_override"
+  fi
   source "$CAP_INSTALL_PATH/lib/environment.sh"
   if [ -n "$environment_override" ]; then
     CAP_ENV="$environment_override"
@@ -85,7 +88,7 @@ EOF
     cap_run_dry_run
   else
     sbatch -D "$job_directory" \
-      --job-name="$CAP_PROJECT_NAME\_${job_name%.*}" \
+      --job-name="$CAP_PROJECT_NAME-${job_name%.*}" \
       --output "$log_full_path/$log_file_name.out" \
       --error "$log_full_path/$log_file_name.err" \
       <<EOF

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -67,6 +67,9 @@ if [ -f "$CAP_PROJECT_PATH/.caprc" ]; then
   # shellcheck disable=SC1091
   source "$CAP_PROJECT_PATH/.caprc"
 fi
+if [ -n "$environment_override" ]; then
+  CAP_ENV="$environment_override"
+fi
 if [ -f "$CAP_PROJECT_PATH/config/environments/$CAP_ENV.sh" ]; then
   source "$CAP_INSTALL_PATH/lib/environment_functions.sh"
   # shellcheck disable=SC1090

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -11,7 +11,7 @@ cap_data_download() {
   local file_name
   file_name=$(basename "$cap_data_download_url")
   local output_name
-  output_name=$(echo "$file_name" | sed 's|\.tar.*||')
+  output_name=$(echo "${file_name//\.tar.*/}")
 
   # Download data if the final output does not exist.
   if [ -e "$CAP_DATA_PATH/$output_name" ]; then

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -11,7 +11,7 @@ cap_data_download() {
   local file_name
   file_name=$(basename "$cap_data_download_url")
   local output_name
-  output_name=$(echo "${file_name//\.tar.*/}")
+  output_name="${file_name//\.tar.*/}"
 
   # Download data if the final output does not exist.
   if [ -e "$CAP_DATA_PATH/$output_name" ]; then

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -44,7 +44,7 @@ cap_data_download() {
         # Unzip and remove downloads that are compressed files.
         *.gz)
           (
-            cd "$CAP_DATA_PATH"
+            cd "$CAP_DATA_PATH" || exit
             gunzip "$file_name"
           )
           ;;

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -12,6 +12,7 @@ cap_data_download() {
   file_name=$(basename "$cap_data_download_url")
   local output_name
   output_name="${file_name//\.tar.*/}"
+  output_name="${output_name//\.gz/}"
 
   # Download data if the final output does not exist.
   if [ -e "$CAP_DATA_PATH/$output_name" ]; then
@@ -32,11 +33,22 @@ cap_data_download() {
       fi
     fi
 
-    # Untar and remove downloads that are tar archives.
     if file "$download_file" | grep -q -E '(tar archive)|(gzip compressed data)'; then
-      if tar -xf "$download_file" -C "$CAP_DATA_PATH"; then
-        rm "$download_file"
-      fi
+      case "$file_name" in
+        # Untar and remove downloads that are tar archives.
+        *.tar|*.tar.gz)
+          if tar -xf "$download_file" -C "$CAP_DATA_PATH"; then
+            rm "$download_file"
+          fi
+          ;;
+        # Unzip and remove downloads that are compressed files.
+        *.gz)
+          (
+            cd "$CAP_DATA_PATH"
+            gunzip "$file_name"
+          )
+          ;;
+      esac
     fi
   fi
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -8,8 +8,10 @@ cap_data_download() {
   # the name of the output. This assumption will probably need
   # to be removed but we will wait until we have a real example
   # before we try to change this.
-  local file_name=$(basename "$cap_data_download_url")
-  local output_name=$(echo "$file_name" | sed 's|\.tar.*||')
+  local file_name
+  file_name=$(basename "$cap_data_download_url")
+  local output_name
+  output_name=$(echo "$file_name" | sed 's|\.tar.*||')
 
   # Download data if the final output does not exist.
   if [ -e "$CAP_DATA_PATH/$output_name" ]; then

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1,2 +1,73 @@
 #!/bin/bash
 
+cap_data_download() {
+  cap_data_download_parse_commandline_parameters "$@"
+
+  # Determine the output folder or file name.
+  # There is an assumption that the name of a tar file matches
+  # the name of the output. This assumption will probably need
+  # to be removed but we will wait until we have a real example
+  # before we try to change this.
+  local file_name=$(basename "$cap_data_download_url")
+  local output_name=$(echo "$file_name" | sed 's|\.tar.*||')
+
+  # Download data if the final output does not exist.
+  if [ -e "$CAP_DATA_PATH/$output_name" ]; then
+    echo "$file_name has already been downloaded"
+  else
+    local download_file="$CAP_DATA_PATH/$file_name"
+
+    # Download the file.
+    wget -nv -O "$download_file" "$cap_data_download_url"
+
+    # Check the md5sum if it is provided.
+    if [ -n "$cap_data_download_md5sum" ]; then
+      if echo "$cap_data_download_md5sum  $download_file" | md5sum -c -; then
+        echo "File download checksum verified!"
+      else
+        echo "File download checksum verification failed!" >&2
+        exit 1
+      fi
+    fi
+
+    # Untar and remove downloads that are tar archives.
+    if file "$download_file" | grep -q -E '(tar archive)|(gzip compressed data)'; then
+      if tar -xf "$download_file" -C "$CAP_DATA_PATH"; then
+        rm "$download_file"
+      fi
+    fi
+  fi
+}
+
+cap_data_download_parse_commandline_parameters() {
+  # Define the named commandline options
+  if ! OPTIONS=$(getopt -o "" --long md5sum: -- "$@"); then
+    echo "See CAPTURE help for cap_data_download." >&2
+    exit 1
+  fi
+  eval set -- "$OPTIONS"
+
+  # Set default values for the named parameters
+  cap_data_download_md5sum=""
+
+  # Parse the optional named command line options
+  while true; do
+    case "$1" in
+      --md5sum)
+        cap_data_download_md5sum="$2"
+        shift 2 ;;
+      --)
+        shift
+        break;;
+    esac
+  done
+
+  # Check that the required file url parameter was provided
+  if [ "$#" -ne 1 ]; then
+    echo "Error: incorrect number of parameters" >&2
+    echo "Usage: cap_data_download [options] URL" >&2
+    echo "See CAPTURE help for cap_data_download" >&2
+    exit 1
+  fi
+  cap_data_download_url=$1
+}


### PR DESCRIPTION
The cap_data_download method downloads data from a url and puts it in the data directory.  If the file is a .tar* then the contents will be extracted into the data directory and the original file will be deleted.  A --md5sum option can be used to provide a sum for the file and it will be verified after the download.

Setup:
```
cd ~/bin/capture
git checkout main
git pull
git checkout cap-data-download
git submodule update --init --recursive

```
Change to your project directory and then change directory to a new or existing project.

Create a script in the source directory like the following.
```
#!/bin/bash

#SBATCH --nodes=1
#SBATCH --ntasks=1
#SBATCH --mem-per-cpu=16G
#SBATCH --cpus-per-task=1
#SBATCH --time=1:00:00
#SBATCH --partition=medium

cap_data_download \
  --md5sum="37c51137ccaeabd4d151f80dc86ce0b3" \
  "https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-GRCm39-2024-A.tar.gz"
```
Run the script with `cap run`.  If you are using a previous testing project, make sure there is not a symlink or directory already in the `data` directory.  Also, if you are using the `lasseignelab` environment by default, then either use the `-e default` option or make sure this download is not being symlinked with `cap_data_link`.

Things to test:
- With and without `--md5sum` option
- With invalid md5sum
- With invalid url
- When the download already exists in the data directory
- Other scenarios you can imagine

To get back to the released version of CAPTURE run the following command.
```
cap update

```