### PR TITLE
Add cap_array_value function

### DIFF
--- a/.github/workflows/bats-tests.yml
+++ b/.github/workflows/bats-tests.yml
@@ -1,0 +1,26 @@
+name: Run BATS tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Set up BATS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+
+      - name: Run BATS tests
+        run: bats tests/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -298,15 +298,22 @@ Retrieves a value from an array file based on a zero based index.
 cap_arrary_value FILE [INDEX]
 ```
 - `FILE` The file containing an array value on each line.
-- `INDEX` The optional zero based index for the value of the array. If a value
-    is not provided then SLURM_ARRAY_TASK_ID environment variable will be used
-    as the default.
+- `INDEX` The optional zero based index for the value of the array. If a value is not provided then SLURM_ARRAY_TASK_ID environment variable will be used as the default.
 
-The folowing example will retrieve an array value based on the Slurm environment
+Example that retrieves array values based on the Slurm environment
 variable default index.
 ```
 sample=$(cap_array_value "$CAP_DATA_PATH/sample_list.array")
 ```
+
+Example with a `for` loop:
+```
+for index in {1..10}; do
+  sample=$(cap_array_value "$CAP_DATA_PATH/sample_list.array" index)
+  # Do something with each sample value.
+done
+```
+
 ## cap_data_download
 Downloads data into the data directory.
 ```

--- a/README.md
+++ b/README.md
@@ -292,12 +292,27 @@ v0.0.3
 
 ```
 # Helper Functions
+## cap_array_value
+Retrieves a value from an array file based on a zero based index.
+```
+cap_arrary_value FILE [INDEX]
+```
+- `FILE` The file containing an array value on each line.
+- `INDEX` The optional zero based index for the value of the array. If a value
+    is not provided then SLURM_ARRAY_TASK_ID environment variable will be used
+    as the default.
+
+The folowing example will retrieve an array value based on the Slurm environment
+variable default index.
+```
+sample=$(cap_array_value "$CAP_DATA_PATH/sample_list.array")
+```
 ## cap_data_download
 Downloads data into the data directory.
 ```
 cap_data_download [options] URL
 ```
-`URL` The URL of the file to download.
+- `URL` The URL of the file to download.
 
 Options
 - `--md5sum` The md5sum to check against the file being downloaded.
@@ -319,7 +334,7 @@ Creates a symbolic link in the data directory.
 ```
 cap_data_link <FILE>|<DIR>
 ```
-`<FILE>|<DIR>` The full path to a file or directory.
+- `<FILE>|<DIR>` The full path to a file or directory.
 
 The symbolic link will have the same name as the specified file or directory
 and will be created in the directory specified by `CAP_DATA_PATH` which

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -6,5 +6,6 @@ CAP_INSTALL_PATH=$(dirname "$cap_install_fullpath")
 
 # Load commands
 for file in "$CAP_INSTALL_PATH"/lib/functions/*.sh; do
+    # shellcheck disable=SC1090
     source "$file"
 done

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1,87 +1,10 @@
 #!/bin/bash
 
-cap_data_download() {
-  cap_data_download_parse_commandline_parameters "$@"
+# Location where the CAPTURE framework was installed.
+cap_install_fullpath=$(command -v cap)
+CAP_INSTALL_PATH=$(dirname "$cap_install_fullpath")
 
-  # Determine the output folder or file name.
-  # There is an assumption that the name of a tar file matches
-  # the name of the output. This assumption will probably need
-  # to be removed but we will wait until we have a real example
-  # before we try to change this.
-  local file_name
-  file_name=$(basename "$cap_data_download_url")
-  local output_name
-  output_name="${file_name//\.tar.*/}"
-  output_name="${output_name//\.gz/}"
-
-  # Download data if the final output does not exist.
-  if [ -e "$CAP_DATA_PATH/$output_name" ]; then
-    echo "$file_name has already been downloaded"
-  else
-    local download_file="$CAP_DATA_PATH/$file_name"
-
-    # Download the file.
-    wget -nv -O "$download_file" "$cap_data_download_url"
-
-    # Check the md5sum if it is provided.
-    if [ -n "$cap_data_download_md5sum" ]; then
-      if echo "$cap_data_download_md5sum  $download_file" | md5sum -c -; then
-        echo "File download checksum verified!"
-      else
-        echo "File download checksum verification failed!" >&2
-        exit 1
-      fi
-    fi
-
-    if file "$download_file" | grep -q -E '(tar archive)|(gzip compressed data)'; then
-      case "$file_name" in
-        # Untar and remove downloads that are tar archives.
-        *.tar|*.tar.gz)
-          if tar -xf "$download_file" -C "$CAP_DATA_PATH"; then
-            rm "$download_file"
-          fi
-          ;;
-        # Unzip and remove downloads that are compressed files.
-        *.gz)
-          (
-            cd "$CAP_DATA_PATH" || exit
-            gunzip "$file_name"
-          )
-          ;;
-      esac
-    fi
-  fi
-}
-
-cap_data_download_parse_commandline_parameters() {
-  # Define the named commandline options
-  if ! OPTIONS=$(getopt -o "" --long md5sum: -- "$@"); then
-    echo "See CAPTURE help for cap_data_download." >&2
-    exit 1
-  fi
-  eval set -- "$OPTIONS"
-
-  # Set default values for the named parameters
-  cap_data_download_md5sum=""
-
-  # Parse the optional named command line options
-  while true; do
-    case "$1" in
-      --md5sum)
-        cap_data_download_md5sum="$2"
-        shift 2 ;;
-      --)
-        shift
-        break;;
-    esac
-  done
-
-  # Check that the required file url parameter was provided
-  if [ "$#" -ne 1 ]; then
-    echo "Error: incorrect number of parameters" >&2
-    echo "Usage: cap_data_download [options] URL" >&2
-    echo "See CAPTURE help for cap_data_download" >&2
-    exit 1
-  fi
-  cap_data_download_url=$1
-}
+# Load commands
+for file in "$CAP_INSTALL_PATH"/lib/functions/*.sh; do
+    source "$file"
+done

--- a/lib/functions/cap_array_value.sh
+++ b/lib/functions/cap_array_value.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cap_array_value() {
+  # Check that the required file name parameter was provided
+  if [ ! "$#" -ge 1 ]; then
+    echo "Error: incorrect number of parameters" >&2
+    echo "Usage: cap_array_value FILE [INDEX]" >&2
+    echo "See CAPTURE documentation for detailed help." >&2
+    exit 1
+  fi
+  local array_file_name
+  array_file_name=$1
+
+  # if an optional array index was not provided then default to the slurm
+  # task id.
+  local array_index
+  if [ -z "$2" ]; then
+    array_index="$SLURM_ARRAY_TASK_ID"
+  else
+    array_index="$2"
+  fi
+
+  local array_list
+  mapfile -t array_list < "$array_file_name"
+  echo "${array_list[$array_index]}"
+}

--- a/lib/functions/cap_array_value.sh
+++ b/lib/functions/cap_array_value.sh
@@ -2,14 +2,14 @@
 
 cap_array_value() {
   # Check that the required file name parameter was provided
-  if [ ! "$#" -ge 1 ]; then
+  if [ "$#" -lt 1 ]; then
     echo "Error: incorrect number of parameters" >&2
     echo "Usage: cap_array_value FILE [INDEX]" >&2
     echo "See CAPTURE documentation for detailed help." >&2
     exit 1
   fi
-  local array_file_name
-  array_file_name=$1
+  local array_file
+  array_file=$1
 
   # if an optional array index was not provided then default to the slurm
   # task id.
@@ -21,6 +21,10 @@ cap_array_value() {
   fi
 
   local array_list
-  mapfile -t array_list < "$array_file_name"
+  if [ -f "$array_file" ]; then
+    # If the input is a file then process the file.
+    mapfile -t array_list < "$array_file"
+  fi
+
   echo "${array_list[$array_index]}"
 }

--- a/lib/functions/cap_array_value.sh
+++ b/lib/functions/cap_array_value.sh
@@ -5,6 +5,10 @@ cap_array_value() {
   if [ "$#" -lt 1 ]; then
     echo "Error: incorrect number of parameters" >&2
     echo "Usage: cap_array_value FILE [INDEX]" >&2
+    echo "" >&2
+    echo "The FILE parameter is required and should be a text file with one" >&2
+    echo "value per line." >&2
+    echo "" >&2
     echo "See CAPTURE documentation for detailed help." >&2
     exit 1
   fi

--- a/lib/functions/cap_data_download.sh
+++ b/lib/functions/cap_data_download.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+cap_data_download() {
+  cap_data_download_parse_commandline_parameters "$@"
+
+  # Determine the output folder or file name.
+  # There is an assumption that the name of a tar file matches
+  # the name of the output. This assumption will probably need
+  # to be removed but we will wait until we have a real example
+  # before we try to change this.
+  local file_name
+  file_name=$(basename "$cap_data_download_url")
+  local output_name
+  output_name="${file_name//\.tar.*/}"
+  output_name="${output_name//\.gz/}"
+
+  # Download data if the final output does not exist.
+  if [ -e "$CAP_DATA_PATH/$output_name" ]; then
+    echo "$file_name has already been downloaded"
+  else
+    local download_file="$CAP_DATA_PATH/$file_name"
+
+    # Download the file.
+    wget -nv -O "$download_file" "$cap_data_download_url"
+
+    # Check the md5sum if it is provided.
+    if [ -n "$cap_data_download_md5sum" ]; then
+      if echo "$cap_data_download_md5sum  $download_file" | md5sum -c -; then
+        echo "File download checksum verified!"
+      else
+        echo "File download checksum verification failed!" >&2
+        exit 1
+      fi
+    fi
+
+    if file "$download_file" | grep -q -E '(tar archive)|(gzip compressed data)'; then
+      case "$file_name" in
+        # Untar and remove downloads that are tar archives.
+        *.tar|*.tar.gz)
+          if tar -xf "$download_file" -C "$CAP_DATA_PATH"; then
+            rm "$download_file"
+          fi
+          ;;
+        # Unzip and remove downloads that are compressed files.
+        *.gz)
+          (
+            cd "$CAP_DATA_PATH" || exit
+            gunzip "$file_name"
+          )
+          ;;
+      esac
+    fi
+  fi
+}
+
+cap_data_download_parse_commandline_parameters() {
+  # Define the named commandline options
+  if ! OPTIONS=$(getopt -o "" --long md5sum: -- "$@"); then
+    echo "See CAPTURE help for cap_data_download." >&2
+    exit 1
+  fi
+  eval set -- "$OPTIONS"
+
+  # Set default values for the named parameters
+  cap_data_download_md5sum=""
+
+  # Parse the optional named command line options
+  while true; do
+    case "$1" in
+      --md5sum)
+        cap_data_download_md5sum="$2"
+        shift 2 ;;
+      --)
+        shift
+        break;;
+    esac
+  done
+
+  # Check that the required file url parameter was provided
+  if [ "$#" -ne 1 ]; then
+    echo "Error: incorrect number of parameters" >&2
+    echo "Usage: cap_data_download [options] URL" >&2
+    echo "See CAPTURE help for cap_data_download" >&2
+    exit 1
+  fi
+  cap_data_download_url=$1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "capture",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "bats": "^1.11.0"
+      }
+    },
+    "node_modules/bats": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.11.0.tgz",
+      "integrity": "sha512-qiKdnS4ID3bJ1MaEOKuZe12R4w+t+psJF0ICj+UdkiHBBoObPMHv8xmD3w6F4a5qwUyZUHS+413lxENBNy8xcQ==",
+      "dev": true,
+      "bin": {
+        "bats": "bin/bats"
+      }
+    }
+  },
+  "dependencies": {
+    "bats": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.11.0.tgz",
+      "integrity": "sha512-qiKdnS4ID3bJ1MaEOKuZe12R4w+t+psJF0ICj+UdkiHBBoObPMHv8xmD3w6F4a5qwUyZUHS+413lxENBNy8xcQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "bats": "^1.11.0"
   },
   "scripts": {
-    "test": "bats -r test"
+    "test": "bats -r tests"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {
+    "bats": "^1.11.0"
+  },
+  "scripts": {
+    "test": "bats -r test"
+  }
+}

--- a/test/lib/functions/test_cap_array_value.bats
+++ b/test/lib/functions/test_cap_array_value.bats
@@ -1,0 +1,57 @@
+source "lib/functions/cap_array_value.sh"
+
+@test "cap_array_value: Get the first array value with parameter" {
+  temp_file="$BATS_TMPDIR/test.array"
+  cat <<EOF > $temp_file
+first
+second
+third
+EOF
+  run cap_array_value $temp_file 0
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "first" ]
+}
+
+@test "cap_array_value: Get the second array value with parameter" {
+  temp_file="$BATS_TMPDIR/test.array"
+  cat <<EOF > $temp_file
+first
+second
+third
+EOF
+  run cap_array_value $temp_file 1
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "second" ]
+}
+
+@test "cap_array_value: Get the first array value with Slurm" {
+  temp_file="$BATS_TMPDIR/test.array"
+  cat <<EOF > $temp_file
+first
+second
+third
+EOF
+
+  export SLURM_ARRAY_TASK_ID=0
+  run cap_array_value $temp_file
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "first" ]
+}
+
+@test "cap_array_value: Get the second array value with Slurm" {
+  temp_file="$BATS_TMPDIR/test.array"
+  cat <<EOF > $temp_file
+first
+second
+third
+EOF
+
+  export SLURM_ARRAY_TASK_ID=1
+  run cap_array_value $temp_file
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "second" ]
+}

--- a/tests/lib/functions/test_cap_array_value.bats
+++ b/tests/lib/functions/test_cap_array_value.bats
@@ -1,56 +1,40 @@
 source "lib/functions/cap_array_value.sh"
 
-@test "cap_array_value: Get the first array value with parameter" {
-  temp_file="$BATS_TMPDIR/test.array"
-  cat <<EOF > $temp_file
+setup() {
+  TEMP_FILE="$BATS_TMPDIR/test.array"
+  export TEMP_FILE
+  cat <<EOF > $TEMP_FILE
 first
 second
 third
 EOF
-  run cap_array_value $temp_file 0
+}
+
+@test "cap_array_value: Get the first array value with parameter" {
+  run cap_array_value $TEMP_FILE 0
 
   [ "$status" -eq 0 ]
   [ "$output" = "first" ]
 }
 
 @test "cap_array_value: Get the second array value with parameter" {
-  temp_file="$BATS_TMPDIR/test.array"
-  cat <<EOF > $temp_file
-first
-second
-third
-EOF
-  run cap_array_value $temp_file 1
+  run cap_array_value $TEMP_FILE 1
 
   [ "$status" -eq 0 ]
   [ "$output" = "second" ]
 }
 
 @test "cap_array_value: Get the first array value with Slurm" {
-  temp_file="$BATS_TMPDIR/test.array"
-  cat <<EOF > $temp_file
-first
-second
-third
-EOF
-
   export SLURM_ARRAY_TASK_ID=0
-  run cap_array_value $temp_file
+  run cap_array_value $TEMP_FILE
 
   [ "$status" -eq 0 ]
   [ "$output" = "first" ]
 }
 
 @test "cap_array_value: Get the second array value with Slurm" {
-  temp_file="$BATS_TMPDIR/test.array"
-  cat <<EOF > $temp_file
-first
-second
-third
-EOF
-
   export SLURM_ARRAY_TASK_ID=1
-  run cap_array_value $temp_file
+  run cap_array_value $TEMP_FILE
 
   [ "$status" -eq 0 ]
   [ "$output" = "second" ]


### PR DESCRIPTION
The cap_array_value function will retrieve a value from an array file based on it's zero based index.  If no index is provided the Slurm array environment variable will be used by default.
Setup:
```
cd ~/bin/capture
git checkout main
git pull
git checkout cap-array-value
git submodule update --init --recursive

```
Create a test project:
```
cap new hello
cd hello

```
Create an array file `data/person_list.array`:
```
Tabea
Lizzy
Tonie
```
Create a test job `src/01_hello.sh`:
```
#!/bin/bash

#SBATCH --nodes=1
#SBATCH --ntasks=1
#SBATCH --mem-per-cpu=8G
#SBATCH --cpus-per-task=1
#SBATCH --time=00:05:00
#SBATCH --partition=express
#SBATCH --array=0-2

person=$(cap_array_value "$CAP_DATA_PATH/person_list.array")
echo "Hello $person!!"
```
Run the test job:
```
cap run src/01_hello.sh

```
View the test job output:
```
cat logs/*

```
Test other scenarios...

Restore to released CAPTURE after testing:
```
cap update

```