### PR TITLE
Data download md5 error improvements

### DIFF
--- a/commands/run.sh
+++ b/commands/run.sh
@@ -76,8 +76,17 @@ EOF
   # Specify the log file names with their full path. Log file names will
   # begin with <job name>-<date>-<time>-<username>. If the job is an array
   # job then the job array id and task id will be appended.
+  current_user=$(whoami)
   log_full_path=$(realpath "$CAP_LOGS_PATH")
-  log_file_name="${job_name%.*}_$(date "+%Y%m%d_%H%M%S")_%u"
+  log_file_name="${job_name%.*}_$(date "+%Y%m%d_%H%M%S")_$current_user"
+  # Inform the user how to check job output.
+  cat <<EOF
+
+View job output with the following command:
+cat $log_full_path/$log_file_name*
+
+EOF
+  # Add array values to log file name if it's an array job.
   if grep -q -E "^#SBATCH +--array=" "$job_file"; then
     log_file_name="$log_file_name-%A-%a"
   fi
@@ -94,6 +103,7 @@ EOF
       <<EOF
 $slurm_job
 EOF
+    echo
   fi
 }
 

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -28,7 +28,11 @@ cap_data_download() {
       if echo "$cap_data_download_md5sum  $download_file" | md5sum -c -; then
         echo "File download checksum verified!"
       else
-        echo "File download checksum verification failed!" >&2
+        echo
+        echo "File $file_name checksum verification failed!" >&2
+        echo "The file was left in place for debugging purposes.  It will" >&2
+        echo "need to be deleted before attempting another download." >&2
+        echo
         exit 1
       fi
     fi

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -28,11 +28,11 @@ cap_data_download() {
       if echo "$cap_data_download_md5sum  $download_file" | md5sum -c -; then
         echo "File download checksum verified!"
       else
-        echo
+        echo >&2
         echo "File $file_name checksum verification failed!" >&2
         echo "The file was left in place for debugging purposes.  It will" >&2
         echo "need to be deleted before attempting another download." >&2
-        echo
+        echo >&2
         exit 1
       fi
     fi


### PR DESCRIPTION
Added an error message that lets the user know the file was left in place after the md5 check failed.  Some users may not know to look at the output files for the job and may not see the error message.  To help with this problem, instructions are added to `cap run` about how to view the output files in the logs directory.