### PR TITLE
Improve README for environment and cap_data_download

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ v0.0.3
 ## cap_array_value
 Retrieves a value from an array file based on a zero based index.
 ```
-cap_arrary_value FILE [INDEX]
+cap_array_value FILE [INDEX]
 ```
 - `FILE` The file containing an array value on each line.
 - `INDEX` The optional zero based index for the value of the array.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 CAPTURE
 A framework and command line interface (CLI) for computational science.
 
+* [Table of Contents](#table-of-contents)
+
 # Installation
 ```
 curl -sSL https://raw.githubusercontent.com/lasseignelab/capture/refs/heads/main/install.sh | bash
@@ -196,7 +198,7 @@ cat logs/01_down_20241118_090854_tcrumley*
 
 Submitted batch job 29818073
 ```
-Runtime environment:
+### Runtime environment
 
 The runtime environment is configured with the following variables available
 to Slurm scripts.
@@ -295,7 +297,7 @@ $ cap version
 v0.0.3
 
 ```
-# Helper Functions
+# Job Helper Functions
 ## cap_array_value
 Retrieves a value from an array file based on a zero based index.
 ```
@@ -333,6 +335,10 @@ file is a TAR file then it will be unarchived into the data directory.  The
 data directory is specified by `CAP_DATA_PATH` which defaults to
 `CAP_PROJECT_PATH/data`.
 
+If the file or directory already exists in the `data` directory then it will
+not be downloaded again. This is also true when the file or directory has
+been symlinked into the `data` directory by [cap_data_link].
+
 The following example will download and unarchive a directory into
 `CAP_DATA_PATH/refdata-gex-GRCm39-2024-A`.
 ```
@@ -340,8 +346,18 @@ cap_data_download \
   --md5sum="37c51137ccaeabd4d151f80dc86ce0b3" \
   "https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-GRCm39-2024-A.tar.gz"
 ```
+# Environment Helper Functions
+Functions to facilitate setting up environments for CAPTURE to operate in.
+Environments help create reproducible pipelines by allowing authors to
+work in their unique development setup, which may only work for them, and
+reviewers to run pipelines in a default environment that should work anywhere.
+Environment files are stored in the `config/environments` directory.
+
 ## cap_data_link
-Creates a symbolic link in the data directory.
+Creates a symbolic link in the data directory. A common use is to prevent
+duplicate storage of large datasets in the author's compute environment. By
+linking to a shared copy, multiple authors won't create multiple copies. This
+function is often used in conjunction with [cap_data_download].
 ```
 cap_data_link <FILE>|<DIR>
 ```
@@ -351,7 +367,15 @@ The symbolic link will have the same name as the specified file or directory
 and will be created in the directory specified by `CAP_DATA_PATH` which
 defaults to `CAP_PROJECT_PATH/data`.
 
-The following example will create the symbolic link `$CAP_DATA_PATH/mouse`.
+The following example will create a symbolic link at `$CAP_DATA_PATH/mouse`
+and should be included in an environment file in `config/environments`, e.g
+`config/environments/my_lab.sh`. The `$MY_LAB` environment variable should
+be created in a `.caprc` file (See [Runtime environment]).
 ```
 cap_data_link "$MY_LAB/genome/mouse"
+```
+To use the `my_lab` environment when running a job, use the `cap run` command
+with the -e/--environment option like in the following example.
+```
+cap run -e my_lab src/01_download.sh
 ```

--- a/README.md
+++ b/README.md
@@ -377,7 +377,10 @@ Creates a symbolic link in the data directory. A common use is to prevent
 duplicate storage of large datasets in the author's compute environment. By
 linking to a shared copy, multiple authors won't create multiple copies. This
 function is often used in conjunction with
-[cap_data_download](#cap_data_download).
+[cap_data_download](#cap_data_download), where cap_data_link prevents
+cap_data_download from downloading a new version of previously downloaded data
+while ensuring the data will be downloaded in other environments such as the
+default environment.
 ```
 cap_data_link <FILE>|<DIR>
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 CAPTURE
 A framework and command line interface (CLI) for computational science.
 
-* [Table of Contents](#table-of-contents)
+Table of Contents
+- [Installation](#installation)
+- [CLI usage](#cli-usage)
+  - [cap env](#env)
+  - [cap help](#help)
+  - [cap md5](#md5)
+  - [cap new](#new)
+  - [cap run](#run)
+    - [Runtime environment](#runtime-environment)
+  - [cap update](#update)
+  - [cap version](#version)
+- [Job helper functions](#job-helper-functions)
+  - [cap_array_value](#cap_array_value)
+  - [cap_data_download](#cap_data_download)
+- [Environment helper functions](#environment-helper-functions)
+  - [cap_data_link](#cap_data_link)
 
 # Installation
 ```
@@ -12,7 +27,7 @@ source ~/.bash_profile
 ```
 cap update
 ```
-# CLI Usage
+# CLI usage
 The `cap` CLI provides commands to help with reproducible research.
 ```
 cap <command> params...
@@ -297,14 +312,17 @@ $ cap version
 v0.0.3
 
 ```
-# Job Helper Functions
+# Job helper functions
 ## cap_array_value
 Retrieves a value from an array file based on a zero based index.
 ```
 cap_arrary_value FILE [INDEX]
 ```
 - `FILE` The file containing an array value on each line.
-- `INDEX` The optional zero based index for the value of the array. If a value is not provided then SLURM_ARRAY_TASK_ID environment variable will be used as the default.
+- `INDEX` The optional zero based index for the value of the array.
+
+If a value is not provided for `INDEX` then the SLURM_ARRAY_TASK_ID
+environment variable will be used as the default.
 
 Example that retrieves array values based on the Slurm environment
 variable default index.
@@ -337,7 +355,7 @@ data directory is specified by `CAP_DATA_PATH` which defaults to
 
 If the file or directory already exists in the `data` directory then it will
 not be downloaded again. This is also true when the file or directory has
-been symlinked into the `data` directory by [cap_data_link].
+been symlinked into the `data` directory by [cap_data_link](#cap_data_link).
 
 The following example will download and unarchive a directory into
 `CAP_DATA_PATH/refdata-gex-GRCm39-2024-A`.
@@ -346,7 +364,8 @@ cap_data_download \
   --md5sum="37c51137ccaeabd4d151f80dc86ce0b3" \
   "https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-GRCm39-2024-A.tar.gz"
 ```
-# Environment Helper Functions
+
+# Environment helper functions
 Functions to facilitate setting up environments for CAPTURE to operate in.
 Environments help create reproducible pipelines by allowing authors to
 work in their unique development setup, which may only work for them, and
@@ -357,7 +376,8 @@ Environment files are stored in the `config/environments` directory.
 Creates a symbolic link in the data directory. A common use is to prevent
 duplicate storage of large datasets in the author's compute environment. By
 linking to a shared copy, multiple authors won't create multiple copies. This
-function is often used in conjunction with [cap_data_download].
+function is often used in conjunction with
+[cap_data_download](#cap_data_download).
 ```
 cap_data_link <FILE>|<DIR>
 ```
@@ -370,7 +390,7 @@ defaults to `CAP_PROJECT_PATH/data`.
 The following example will create a symbolic link at `$CAP_DATA_PATH/mouse`
 and should be included in an environment file in `config/environments`, e.g
 `config/environments/my_lab.sh`. The `$MY_LAB` environment variable should
-be created in a `.caprc` file (See [Runtime environment]).
+be created in a `.caprc` file (See [Runtime environment](#runtime-environment).
 ```
 cap_data_link "$MY_LAB/genome/mouse"
 ```

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ defaults to `CAP_PROJECT_PATH/data`.
 The following example will create a symbolic link at `$CAP_DATA_PATH/mouse`
 and should be included in an environment file in `config/environments`, e.g
 `config/environments/my_lab.sh`. The `$MY_LAB` environment variable should
-be created in a `.caprc` file (See [Runtime environment](#runtime-environment).
+be created in a `.caprc` file (See [Runtime environment](#runtime-environment)).
 ```
 cap_data_link "$MY_LAB/genome/mouse"
 ```


### PR DESCRIPTION
Improving the README based on feedback from TC.

> I missed some of the code review so I am trying to play around with capture for this Yoder macrophage work. I wanted to give some feedback 
[@Tonie Crumley](https://lasseignelab.slack.com/team/U06VDPHCLHK)
.
The documentation around setting up the user .caprc is a little hidden I had to get Tabea to explain to me how to set up the lasseignelab env where it would actually use the $LASSEIGNE_LAB_PATH.
There is not documentation in the Readme that tells you how to use cap_data_link. If I run cap_data_link outside of putting it in a lasseignelab.sh file in config/environments, it just says there is no cap_data_link. I think thats fine, but the readme should specify how to include that in the env.sh file.
There isn't documentation on the cap_data_download not downloading a file if it already exits and how that works with cap_data_link