### PR TITLE
Add tab completion to the CAPTURE cap command line

### DIFF
--- a/cap_completion.sh
+++ b/cap_completion.sh
@@ -1,19 +1,21 @@
+#!/bin/bash
+
 # Function to handle tab completion for CAPTURE
 _cap_completion() {
-	local currrent subcommand subcommands
+	local current subcommand subcommands
 	current="${COMP_WORDS[COMP_CWORD]}"
 	subcommand="${COMP_WORDS[1]}"
 	subcommands="env help md5 new run update version"
 
   if [[ "${COMP_CWORD}" -eq 1 ]]; then
 		# Show the cap subcommand list.
-    COMPREPLY=( $(compgen -W "${subcommands}" -- "${current}") )
+    mapfile -t COMPREPLY < <(compgen -W "${subcommands}" -- "${current}")
   else
 		case "$subcommand" in
 			"help")
 				# Show the cap subcommand list.
 				if [[ "${COMP_CWORD}" == 2 ]]; then
-					COMPREPLY=( $(compgen -W "${subcommands}" -- "${current}") )
+					mapfile -t COMPREPLY < <(compgen -W "${subcommands}" -- "${current}")
 				fi
 				;;
 			"md5"|"run")

--- a/cap_completion.sh
+++ b/cap_completion.sh
@@ -1,0 +1,32 @@
+# Function to handle tab completion for CAPTURE
+_cap_completion() {
+	local currrent subcommand subcommands
+	current="${COMP_WORDS[COMP_CWORD]}"
+	subcommand="${COMP_WORDS[1]}"
+	subcommands="env help md5 new run update verify version"
+
+  if [[ "${COMP_CWORD}" -eq 1 ]]; then
+		# Show the cap subcommand list.
+    COMPREPLY=( $(compgen -W "${subcommands}" -- "${current}") )
+  else
+		case "$subcommand" in
+			"help")
+				# Show the cap subcommand list.
+				if [[ "${COMP_CWORD}" == 2 ]]; then
+					COMPREPLY=( $(compgen -W "${subcommands}" -- "${current}") )
+				fi
+				;;
+			"md5"|"run"|"verify")
+				# Tab compete with file and directory names.
+				compopt -o default -o plusdirs
+				;;
+			*)
+				# Don't tab complete.
+				COMPREPLY=()
+		esac
+  fi
+}
+
+# Register the completion function for "mytool"
+complete -F _cap_completion cap
+

--- a/cap_completion.sh
+++ b/cap_completion.sh
@@ -2,30 +2,30 @@
 
 # Function to handle tab completion for CAPTURE
 _cap_completion() {
-	local current subcommand subcommands
-	current="${COMP_WORDS[COMP_CWORD]}"
-	subcommand="${COMP_WORDS[1]}"
-	subcommands="env help md5 new run update version"
+  local current subcommand subcommands
+  current="${COMP_WORDS[COMP_CWORD]}"
+  subcommand="${COMP_WORDS[1]}"
+  subcommands="env help md5 new run update version"
 
   if [[ "${COMP_CWORD}" -eq 1 ]]; then
-		# Show the cap subcommand list.
+    # Show the cap subcommand list.
     mapfile -t COMPREPLY < <(compgen -W "${subcommands}" -- "${current}")
   else
-		case "$subcommand" in
-			"help")
-				# Show the cap subcommand list.
-				if [[ "${COMP_CWORD}" == 2 ]]; then
-					mapfile -t COMPREPLY < <(compgen -W "${subcommands}" -- "${current}")
-				fi
-				;;
-			"md5"|"run")
-				# Tab compete with file and directory names.
-				compopt -o default -o plusdirs
-				;;
-			*)
-				# Don't tab complete.
-				COMPREPLY=()
-		esac
+    case "$subcommand" in
+      "help")
+        # Show the cap subcommand list.
+        if [[ "${COMP_CWORD}" == 2 ]]; then
+          mapfile -t COMPREPLY < <(compgen -W "${subcommands}" -- "${current}")
+        fi
+        ;;
+      "md5"|"run")
+        # Tab compete with file and directory names.
+        compopt -o default -o plusdirs
+        ;;
+      *)
+        # Don't tab complete.
+        COMPREPLY=()
+    esac
   fi
 }
 

--- a/cap_completion.sh
+++ b/cap_completion.sh
@@ -3,7 +3,7 @@ _cap_completion() {
 	local currrent subcommand subcommands
 	current="${COMP_WORDS[COMP_CWORD]}"
 	subcommand="${COMP_WORDS[1]}"
-	subcommands="env help md5 new run update verify version"
+	subcommands="env help md5 new run update version"
 
   if [[ "${COMP_CWORD}" -eq 1 ]]; then
 		# Show the cap subcommand list.
@@ -16,7 +16,7 @@ _cap_completion() {
 					COMPREPLY=( $(compgen -W "${subcommands}" -- "${current}") )
 				fi
 				;;
-			"md5"|"run"|"verify")
+			"md5"|"run")
 				# Tab compete with file and directory names.
 				compopt -o default -o plusdirs
 				;;

--- a/commands/update.sh
+++ b/commands/update.sh
@@ -38,6 +38,7 @@ cap_update() {
   git checkout main
   git pull
   git submodule update --init --recursive
+  . "$CAP_INSTALL_PATH/configure.sh"
 
   echo
 

--- a/configure.sh
+++ b/configure.sh
@@ -1,0 +1,15 @@
+# Check if $HOME/bin/capture is already in PATH
+if ! grep -q "\$HOME/bin/capture" ~/.bash_profile; then
+	echo "Adding $HOME/bin/capture to PATH in .bash_profile"
+	echo "export PATH=\"\$PATH:\$HOME/bin/capture\"" >> ~/.bash_profile
+else
+	echo "$HOME/bin/capture is already in PATH"
+fi
+
+# Check if cap_completion is configured.
+if ! grep -q "cap_completion.sh" ~/.bash_profile; then
+	echo "Adding CAPTURE tab completion to .bash_profile"
+	echo ". \$HOME/bin/capture/cap_completion.sh" >> ~/.bash_profile
+else
+	echo "CAPTURE tab completion is already configured."
+fi

--- a/configure.sh
+++ b/configure.sh
@@ -2,16 +2,16 @@
 
 # Check if $HOME/bin/capture is already in PATH
 if ! grep -q "\$HOME/bin/capture" ~/.bash_profile; then
-	echo "Adding $HOME/bin/capture to PATH in .bash_profile"
-	echo "export PATH=\"\$PATH:\$HOME/bin/capture\"" >> ~/.bash_profile
+  echo "Adding $HOME/bin/capture to PATH in .bash_profile"
+  echo "export PATH=\"\$PATH:\$HOME/bin/capture\"" >> ~/.bash_profile
 else
-	echo "$HOME/bin/capture is already in PATH"
+  echo "$HOME/bin/capture is already in PATH"
 fi
 
 # Check if cap_completion is configured.
 if ! grep -q "cap_completion.sh" ~/.bash_profile; then
-	echo "Adding CAPTURE tab completion to .bash_profile"
-	echo ". \$HOME/bin/capture/cap_completion.sh" >> ~/.bash_profile
+  echo "Adding CAPTURE tab completion to .bash_profile"
+  echo ". \$HOME/bin/capture/cap_completion.sh" >> ~/.bash_profile
 else
-	echo "CAPTURE tab completion is already configured."
+  echo "CAPTURE tab completion is already configured."
 fi

--- a/configure.sh
+++ b/configure.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Check if $HOME/bin/capture is already in PATH
 if ! grep -q "\$HOME/bin/capture" ~/.bash_profile; then
 	echo "Adding $HOME/bin/capture to PATH in .bash_profile"

--- a/install.sh
+++ b/install.sh
@@ -14,12 +14,6 @@ $ cap update
 EOF
 else
   git clone --recurse-submodules https://github.com/lasseignelab/capture.git
-
-  # Check if $HOME/bin/capture is already in PATH
-  if ! grep -q "\$HOME/bin/capture" ~/.bash_profile; then
-    echo "Adding $HOME/bin/capture to PATH in .bash_profile"
-    echo "export PATH=\"\$PATH:\$HOME/bin/capture\"" >> ~/.bash_profile
-  else
-    echo "$HOME/bin/capture is already in PATH"
-  fi
+  cd capture
+  . configure.sh
 fi

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,6 @@ $ cap update
 EOF
 else
   git clone --recurse-submodules https://github.com/lasseignelab/capture.git
-  cd capture
+  cd capture || exit
   . configure.sh
 fi


### PR DESCRIPTION
Tab completion makes CLI interfaces easier to discover and use.

Setup for testing:
```
cd ~/bin/capture
git checkout main
git pull
git checkout tab-completion
source ./configure.sh
source ~/.bash_profile

```
Testing:
- The cap command and help subcommand should show all cap commands for tab completion.
- The env, new, update, and version subcommands should not show anything for tab completion.
- The md5 and run subcommands should perform file and directory tab completion.

Resetting environment:
```
cap update
sed -i '/cap_completion\.sh/d' ~/.bash_profile

```
After resetting, tab completion will continue to work until you log out and log back in.