### PR TITLE
Add processing of symlinks to cap md5

### DIFF
--- a/commands/md5.sh
+++ b/commands/md5.sh
@@ -140,7 +140,7 @@ EOF
       {
         if [[ "$dry_run" == "true" ]]; then
           # shellcheck disable=SC2068
-          find ${md5_files[@]} "${ignore_filter[@]}" \( "${select_filter[@]}" \) -type f ! -path '*/\.*' | sort
+          find -H -L ${md5_files[@]} "${ignore_filter[@]}" \( "${select_filter[@]}" \) -type f ! -path '*/\.*' | sort
         else
           # Compute checksums for all files
           echo -e '\nFiles included:'
@@ -172,7 +172,7 @@ EOF
 ###############################################################################
 cap_md5_find() {
   # shellcheck disable=SC2068
-  find ${md5_files[@]} "${ignore_filter[@]}" \( "${select_filter[@]}" \) -type f ! -path '*/\.*' -exec md5sum {} + | sort -k2,2
+  find -H -L ${md5_files[@]} "${ignore_filter[@]}" \( "${select_filter[@]}" \) -type f ! -path '*/\.*' -exec md5sum {} + | sort -k2,2
 }
 
 cap_md5_parse_commandline_parameters() {

--- a/tests/commands/md5.bats
+++ b/tests/commands/md5.bats
@@ -3,6 +3,14 @@ load ../../node_modules/bats-mock/stub
 
 FIXTURE_PATH="tests/fixtures/md5"
 
+setup() {
+  CAP_DATA_PATH=$(mktemp -d -p "$BATS_TMPDIR")
+}
+
+teardown() {
+  rm -rf ${CAP_DATA_PATH}
+}
+
 # TODO: Test the dry run option.
 
 @test "cap md5: All files in a folder" {
@@ -270,3 +278,27 @@ EOF
     [ "$output" == "srun called correctly" ]
 }
 
+@test "cap md5: Process symlink command line arguments" {
+    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    ln -s $(realpath $FIXTURE_PATH/files) $CAP_DATA_PATH/files
+    cap md5 -o $temp_output $CAP_DATA_PATH/files
+    run diff -u \
+        <(sed "s|$CAP_DATA_PATH||g" $temp_output) \
+        <(sed "s|$FIXTURE_PATH||g" $FIXTURE_PATH/outputs/all.out)
+
+    echo "$output"
+    [ "$status" -eq 0 ]
+}
+
+@test "cap md5: Process symlink subdirectories" {
+    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    mkdir "$CAP_DATA_PATH/output"
+    ln -s $(realpath $FIXTURE_PATH/files) $CAP_DATA_PATH/output/files
+    cap md5 -o $temp_output $CAP_DATA_PATH/output
+    run diff -u \
+        <(sed "s|$CAP_DATA_PATH/output||g" $temp_output) \
+        <(sed "s|$FIXTURE_PATH||g" $FIXTURE_PATH/outputs/all.out)
+
+    echo "$output"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
By default, `find` does not traverse symlinks in the commandline parameters or subdirectories. As a result, if the path given to `cap md5` is a symlink then no files will be processed.  This commit adds the -H and -L options so that symlinks will be followed.

 Setup for testing:
```
cd ~/bin/capture
git checkout main
git pull
git checkout cap-md5-symlink
source ./configure.sh
source ~/.bash_profile

```

Testing:
Change to a testing directory and run the following commands.  Next, look at the `.md5` files and decide whether the correct files were included.  Think of other scenarios to test.
```
mkdir -p symlink_test/data/files
echo "This is a test." > symlink_test/data/files/test.txt
ln -s $(realpath symlink_test/data/files) symlink_test/symlink_files
cap md5 -o symlink_test/no_symlink.md5 symlink_test/data/files
cap md5 -o symlink_test/symlink.md5 symlink_test/symlink_files
cap md5 --ignore "*.md5" -o symlink_test/contains_symlink.md5 symlink_test

```

Reset after testing:
```
cap update

```