### PR TITLE
Add -–subdirectory option to specify a subdirectory in cap_data_download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+## CAPTURE 0.6.1 (March 21, 2024) ##
+
+* Add `--subdirectory` option to `cap_data_download`
+
+## CAPTURE 0.6.0 (March 20, 2024) ##
+
+* Add `--normalize` option to `cap md5`
+
+## CAPTURE 0.5.2 (February 7, 2025) ##
+
+* Fix `cap md5` not working with symlinks
+
+## CAPTURE 0.5.1 (February 5, 2025) ##
+:warning: **WARNING** This is a breaking change!
+
+* Change `cap_data_download` default unzip behaviour.  The previous default was
+to unzip but is now to simply download the file without unzipping.  To unzip
+the `--unzip` option must be added.
+
+    ```bash
+    cap_data_download \
+        --unzip \
+        --md5sum="37c51137ccaeabd4d151f80dc86ce0b3" \
+        "https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-GRCm39-2024-A.tar.gz"
+    ```
+
+## CAPTURE 0.5.0 (January 31, 2025) ##
+
+* Add tab completion for the `cap` command.
+
+## CAPTURE 0.4.0 (January 13, 2025) ##
+
+* Add `cap md5` options --select and --ignore
+
+## CAPTURE 0.3.1 (December 16, 2024) ##
+
+* Upgrade the Bioconductor version
+
+## CAPTURE 0.3.0 (November 20, 2024) ##
+
+* Improve the `cap_data_download` error handling for md5sum errors.
+
+## CAPTURE 0.2.0 (November 15, 2024) ##
+
+* Add the `cap_array_value` job helper function.
+
+## CAPTURE 0.1.0 (October 29, 2024) ##
+
+* Add the `cap run` environment override option `-e`, `--environment`.
+

--- a/README.md
+++ b/README.md
@@ -413,21 +413,35 @@ cap_data_download [options] URL
 Options
 - `--md5sum` The md5sum to check against the file being downloaded.
 - `--unzip`  Unzips and/or unarchives downloaded files.
+- `--subdirectory`  Specifies a subdirectory within the data directory where the
+downloaded file will be stored. If the subdirectory does not exist, it will be created.
 
 The file will be downloaded with the same name as specified by the URL.  If the
 `--unzip` option is provided then it will be unarchived into the data directory.  The
 data directory is specified by `CAP_DATA_PATH` which defaults to
-`CAP_PROJECT_PATH/data`.
+`CAP_PROJECT_PATH/data`. If the `--subdirectory` option is provided, the downloaded
+file will be saved in `CAP_PROJECT_PATH/data/subdirectory`.
 
-If the file or directory already exists in the `data` directory then it will
-not be downloaded again. This is also true when the file or directory has
-been symlinked into the `data` directory by [cap_data_link](#cap_data_link).
+If the file or directory already exists in the `data` directory (or subdirectory
+if `--subdirectory` is provided) then it will not be downloaded again. This is 
+also true when the file or directory has been symlinked into the `data` directory
+by [cap_data_link](#cap_data_link).
 
 The following example will download and unarchive a directory into
 `CAP_DATA_PATH/refdata-gex-GRCm39-2024-A`.
 ```
 cap_data_download \
   --unzip \
+  --md5sum="37c51137ccaeabd4d151f80dc86ce0b3" \
+  "https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-GRCm39-2024-A.tar.gz"
+```
+
+The following example will download and unarchive a directory into
+`CAP_DATA_PATH/reference/refdata-gex-GRCm39-2024-A`.
+```
+cap_data_download \
+  --unzip \
+  --subdirectory "reference" \
   --md5sum="37c51137ccaeabd4d151f80dc86ce0b3" \
   "https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-GRCm39-2024-A.tar.gz"
 ```

--- a/lib/functions/cap_data_download.sh
+++ b/lib/functions/cap_data_download.sh
@@ -58,8 +58,10 @@ cap_data_download() {
           ;;
         # Unzip and remove downloads that are compressed files.
         *.gz)
-          cd "$download_path" || exit
-          gunzip "$file_name"
+          (
+            cd "$download_path" || exit
+            gunzip "$file_name"
+          )
           ;;
         *)
           echo "Error: Unsupported file extension '$file_name'" >&2

--- a/lib/functions/cap_data_download.sh
+++ b/lib/functions/cap_data_download.sh
@@ -52,39 +52,37 @@ cap_data_download() {
       case "$file_name" in
         # Untar and remove downloads that are tar archives.
         *.tar|*.tar.gz)
-        if tar -xf "$download_file" -C "$download_path"; then
-          rm "$download_file"
-        fi
-        ;;
+          if tar -xf "$download_file" -C "$download_path"; then
+            rm "$download_file"
+          fi
+          ;;
         # Unzip and remove downloads that are compressed files.
         *.gz)
-        (
-        cd "$download_path" || exit
-        gunzip "$file_name"
-      )
-      ;;
-    *)
-      echo "Error: Unsupported file extension '$file_name'" >&2
-      exit 1
-      ;;
-  esac
+          cd "$download_path" || exit
+          gunzip "$file_name"
+          ;;
+        *)
+          echo "Error: Unsupported file extension '$file_name'" >&2
+          exit 1
+          ;;
+      esac
     fi
-    fi
-  }
+  fi
+}
 
-  cap_data_download_parse_commandline_parameters() {
-    # Define the named commandline options
-    if ! OPTIONS=$(getopt -o "" --long md5sum:,unzip,subdirectory: -- "$@"); then
-      echo "See CAPTURE help for cap_data_download." >&2
-      exit 1
-    fi
-    eval set -- "$OPTIONS"
+cap_data_download_parse_commandline_parameters() {
+  # Define the named commandline options
+  if ! OPTIONS=$(getopt -o "" --long md5sum:,unzip,subdirectory: -- "$@"); then
+    echo "See CAPTURE help for cap_data_download." >&2
+    exit 1
+  fi
+  eval set -- "$OPTIONS"
 
   # Set default values for the named parameters
   cap_data_download_md5sum=""
   cap_data_download_subdirectory=""
   cap_data_download_unzip=false
-
+  
   # Parse the optional named command line options
   while true; do
     case "$1" in
@@ -102,7 +100,7 @@ cap_data_download() {
         break;;
     esac
   done
-
+  
   # Check that the required file url parameter was provided
   if [ "$#" -ne 1 ]; then
     echo "Error: incorrect number of parameters" >&2

--- a/lib/functions/cap_data_download.sh
+++ b/lib/functions/cap_data_download.sh
@@ -52,14 +52,14 @@ cap_data_download() {
       case "$file_name" in
         # Untar and remove downloads that are tar archives.
         *.tar|*.tar.gz)
-        if tar -xf "$download_file" -C "$CAP_DATA_PATH"; then
+        if tar -xf "$download_file" -C "$download_path"; then
           rm "$download_file"
         fi
         ;;
         # Unzip and remove downloads that are compressed files.
         *.gz)
         (
-        cd "$CAP_DATA_PATH" || exit
+        cd "$download_path" || exit
         gunzip "$file_name"
       )
       ;;

--- a/tests/lib/functions/test_cap_data_download.bats
+++ b/tests/lib/functions/test_cap_data_download.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 teardown() {
-  rm -rf ${CAP_DATA_PATH}
+  rm -rf "${CAP_DATA_PATH}"
 }
 
 @test "cap_data_download: URL not found" {
@@ -24,7 +24,7 @@ teardown() {
 }
 
 @test "cap_data_download: check zipped file existance" {
-  cp $DOWNLOAD_FIXTURE_PATH/file.txt.tar.gz $CAP_DATA_PATH/file.txt.tar.gz
+  cp "$DOWNLOAD_FIXTURE_PATH/file.txt.tar.gz" "$CAP_DATA_PATH/file.txt.tar.gz"
 
   run cap_data_download "https://some.url/file.txt.tar.gz"
 
@@ -33,9 +33,31 @@ teardown() {
 }
 
 @test "cap_data_download: check unzipped file existance" {
-  cp $DOWNLOAD_FIXTURE_PATH/file.txt $CAP_DATA_PATH/file.txt
+  cp "$DOWNLOAD_FIXTURE_PATH/file.txt" "$CAP_DATA_PATH/file.txt"
 
   run cap_data_download "https://some.url/file.txt"
+
+  [ "$status" -eq 0 ]
+  [ "$output" == "file.txt has already been downloaded" ]
+}
+
+@test "cap_data_download: check zipped file existance in subdir" {
+  mkdir "$CAP_DATA_PATH/subdir/"
+
+  cp "$DOWNLOAD_FIXTURE_PATH/file.txt.tar.gz" "$CAP_DATA_PATH/subdir/file.txt.tar.gz"
+
+  run cap_data_download --subdirectory "subdir" "https://some.url/file.txt.tar.gz"
+
+  [ "$status" -eq 0 ]
+  [ "$output" == "file.txt.tar.gz has already been downloaded" ]
+}
+
+@test "cap_data_download: check unzipped file existance in subdir" {
+  mkdir "$CAP_DATA_PATH/subdir/"
+
+  cp "$DOWNLOAD_FIXTURE_PATH/file.txt" "$CAP_DATA_PATH/subdir/file.txt"
+
+  run cap_data_download --subdirectory "subdir" "https://some.url/file.txt"
 
   [ "$status" -eq 0 ]
   [ "$output" == "file.txt has already been downloaded" ]
@@ -48,7 +70,7 @@ teardown() {
 
   unstub wget
 
-  diff $DOWNLOAD_FIXTURE_PATH/file.txt $CAP_DATA_PATH/file.txt
+  diff "$DOWNLOAD_FIXTURE_PATH/file.txt" "$CAP_DATA_PATH/file.txt"
 
   [ "$status" -eq 0 ]
   [ "$output" == "" ]
@@ -61,7 +83,7 @@ teardown() {
 
   unstub wget
 
-  diff $DOWNLOAD_FIXTURE_PATH/file.txt.gz $CAP_DATA_PATH/file.txt.gz
+  diff "$DOWNLOAD_FIXTURE_PATH/file.txt.gz" "$CAP_DATA_PATH/file.txt.gz"
 
   [ "$status" -eq 0 ]
   [ "$output" == "" ]
@@ -74,7 +96,7 @@ teardown() {
 
   unstub wget
 
-  diff $DOWNLOAD_FIXTURE_PATH/file.txt $CAP_DATA_PATH/file.txt
+  diff "$DOWNLOAD_FIXTURE_PATH/file.txt" "$CAP_DATA_PATH/file.txt"
 
   [ "$status" -eq 0 ]
   [ "$output" == "" ]
@@ -87,7 +109,7 @@ teardown() {
 
   unstub wget
 
-  diff $DOWNLOAD_FIXTURE_PATH/file.txt $CAP_DATA_PATH/file.txt
+  diff "$DOWNLOAD_FIXTURE_PATH/file.txt" "$CAP_DATA_PATH/file.txt"
 
   [ "$status" -eq 0 ]
   [ "$output" == "" ]
@@ -100,7 +122,7 @@ teardown() {
 
   unstub wget
 
-  diff $DOWNLOAD_FIXTURE_PATH/file.txt $CAP_DATA_PATH/file.txt
+  diff "$DOWNLOAD_FIXTURE_PATH/file.txt" "$CAP_DATA_PATH/file.txt"
 
   [ "$status" -eq 0 ]
   [ "$output" == "" ]
@@ -125,7 +147,7 @@ $CAP_DATA_PATH/file.txt: OK
 File download checksum verified!
 EOF
 )
-echo $expected
+echo "$expected"
   [ "$status" -eq 0 ]
   [ "$output" == "$expected" ]
 }
@@ -142,7 +164,20 @@ The file was left in place for debugging purposes.  It will
 need to be deleted before attempting another download.
 EOF
 )
-echo $expected
+echo "$expected"
   [ "$status" -eq 1 ]
   [ "$output" == "$expected" ]
+}
+
+@test "cap_data_download subdirectory: download file to subdirectory" {
+  stub wget "-nv --retry-connrefused -O $CAP_DATA_PATH/subdirectory/file.txt https://some.url/file.txt : cp $DOWNLOAD_FIXTURE_PATH/file.txt $CAP_DATA_PATH/subdirectory/file.txt"
+
+  run cap_data_download --subdirectory "subdirectory" "https://some.url/file.txt"
+  
+  unstub wget
+
+  diff "$DOWNLOAD_FIXTURE_PATH/file.txt" "$CAP_DATA_PATH/subdirectory/file.txt"
+
+  [ "$status" -eq 0 ]
+  [ "$output" == "" ]
 }


### PR DESCRIPTION
The --subdirectory option will append the provided path to the end of data/ when saving the downloaded file/directory when using cap_data_download. This option will help keep data/ organized without the user having to mv files after downloading them.

Setup:

```
cd ~/bin/capture
git checkout main
git pull
git checkout data-download-subdirectory
source ./configure.sh
source ~/.bash_profile
```

Testing:

Test cap_data_download with the --subdirectory option.
Test when the file already exists somewhere in data/

Resetting environment:
```
cap update
```