### PR TITLE
Add cap_container

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Table of Contents
 - [Job helper functions](#job-helper-functions)
   - [cap_array_value](#cap_array_value)
   - [cap_data_download](#cap_data_download)
+  - [cap_container](#cap_container)
 - [Environment helper functions](#environment-helper-functions)
   - [cap_data_link](#cap_data_link)
 
@@ -430,6 +431,30 @@ cap_data_download \
   --unzip \
   --md5sum="37c51137ccaeabd4d151f80dc86ce0b3" \
   "https://cf.10xgenomics.com/supp/cell-exp/refdata-gex-GRCm39-2024-A.tar.gz"
+```
+
+## cap_container
+Downloads the proper docker or singularity container.
+```
+cap_container [options] REFERENCE
+```
+- `REFERENCE` The Docker image reference found on DockerHub.
+
+Options
+- `--singularity`  If specified, cap_container will use `singularity pull` instead of `docker pull`.
+
+`cap_container` first checks whether the Docker image or Singularity .sif file
+already exists in `CAP_CONTAINER_PATH`. If the image is not found, it is downloaded
+from DockerHub. By default, `cap_container` uses Docker, but specifying the
+`--singularity` option directs it to generate a Singularity .sif file in the
+`CAP_CONTAINER_PATH` directory instead.
+
+The following example checks for the corresponding .sif file in `CAP_CONTAINER_PATH`.
+If the file is not found, it downloads and converts the Docker image into a Singularity .sif file.
+```
+cap_container \
+  --singularity \
+  "ollama/ollama:0.5.8"
 ```
 
 # Environment helper functions

--- a/README.md
+++ b/README.md
@@ -438,22 +438,30 @@ Downloads the proper docker or singularity container.
 ```
 cap_container [options] REFERENCE
 ```
-- `REFERENCE` The Docker image reference found on DockerHub.
+- `REFERENCE` The Docker image reference found on DockerHub. The format of the reference
+is <owner>/<repository name>:[tag]. If a tag is not provided, if will use the latest release
+and append `_latest`. The following example will result in the creating of ollama_latest.sif.
+```
+cap_container \
+  -c singularity \
+  "ollama/ollama"
+```
 
 Options
-- `--singularity`  If specified, cap_container will use `singularity pull` instead of `docker pull`.
+- `-c singularity`  If specified, cap_container will use `singularity pull` instead of `docker pull`.
 
 `cap_container` first checks whether the Docker image or Singularity .sif file
 already exists in `CAP_CONTAINER_PATH`. If the image is not found, it is downloaded
 from DockerHub. By default, `cap_container` uses Docker, but specifying the
-`--singularity` option directs it to generate a Singularity .sif file in the
+`-c singularity` option directs it to generate a Singularity .sif file in the
 `CAP_CONTAINER_PATH` directory instead.
 
 The following example checks for the corresponding .sif file in `CAP_CONTAINER_PATH`.
-If the file is not found, it downloads and converts the Docker image into a Singularity .sif file.
+If the file is not found, it downloads and converts the Docker image into the 
+Singularity .sif file - ollama_0.5.8.sif.
 ```
 cap_container \
-  --singularity \
+  -c singularity \
   "ollama/ollama:0.5.8"
 ```
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Downloads the proper docker or singularity container.
 cap_container [options] REFERENCE
 ```
 - `REFERENCE` The Docker image reference found on DockerHub. The format of the reference
-is <owner>/<repository_name>:[tag]. If a tag is not provided, if will use the latest release
+is <owner>/<repository_name>:[tag]. If a tag is not provided, it will use the latest release
 and append `_latest`. The following example will result in the creating of ollama_latest.sif.
 ```
 cap_container \

--- a/README.md
+++ b/README.md
@@ -474,7 +474,8 @@ Singularity .sif file - ollama_0.5.8.sif.
 cap_container \
   -c singularity \
   "ollama/ollama:0.5.8"
-=======
+```
+
 The following example will download and unarchive a directory into
 `CAP_DATA_PATH/reference/refdata-gex-GRCm39-2024-A`.
 ```

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ Downloads the proper docker or singularity container.
 cap_container [options] REFERENCE
 ```
 - `REFERENCE` The Docker image reference found on DockerHub. The format of the reference
-is <owner>/<repository name>:[tag]. If a tag is not provided, if will use the latest release
+is <owner>/<repository_name>:[tag]. If a tag is not provided, if will use the latest release
 and append `_latest`. The following example will result in the creating of ollama_latest.sif.
 ```
 cap_container \

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -54,6 +54,9 @@ CAP_RESULTS_PATH=$(realpath "results")
 CAP_CONTAINER_PATH=$(realpath "bin/docker")
 CAP_CONDA_PATH=$(realpath "bin/conda")
 
+# Set all default values
+CAP_CONTAINER_TYPE="docker"
+
 # Load the configuration files.
 if [ -f /etc/caprc ]; then
   # shellcheck disable=SC1091
@@ -103,4 +106,4 @@ export CAP_RESULTS_PATH
 export CAP_CONTAINER_PATH
 export CAP_CONDA_PATH
 export CAP_RANDOM_SEED
-
+export CAP_CONTAINER_TYPE

--- a/lib/functions/cap_container.sh
+++ b/lib/functions/cap_container.sh
@@ -14,7 +14,7 @@ if [[ -f "$CAP_CONTAINER_PATH/$sif_file" ]]; then
 else
   (
   cd "${CAP_CONTAINER_PATH}" || {
-    "Error: Unable to CD to $CAP_CONTAINER_PATH"
+    echo "Error: Unable to CD to $CAP_CONTAINER_PATH"
     exit 1
   }
 

--- a/lib/functions/cap_container.sh
+++ b/lib/functions/cap_container.sh
@@ -38,6 +38,7 @@ fi
 
 cap_container_parse_commandline_parameters() {
   # Set default values for the named parameters
+  # shellcheck disable=SC2153
   cap_container_type="${CAP_CONTAINER_TYPE}"
 
   # Parse the optional named command-line options

--- a/lib/functions/cap_container.sh
+++ b/lib/functions/cap_container.sh
@@ -8,33 +8,33 @@ cap_container() {
   sif_file="${sif_file/:/_}.sif"
 
   # Check if the file exists in CAP_CONTAINER_PATH
-if [[ -f "$CAP_CONTAINER_PATH/$sif_file" ]]; then
+  if [[ -f "$CAP_CONTAINER_PATH/$sif_file" ]]; then
     echo "The $sif_file is already available"
     exit 1
-else
-  (
-  cd "${CAP_CONTAINER_PATH}" || {
-    echo "Error: Unable to CD to $CAP_CONTAINER_PATH"
-    exit 1
-  }
+  else
+    (
+    cd "${CAP_CONTAINER_PATH}" || {
+      echo "Error: Unable to CD to $CAP_CONTAINER_PATH"
+          exit 1
+        }
 
-  case "$cap_container_type" in
-    docker)
-      echo "Pulling Docker image: $cap_container_reference"
-      docker pull "$cap_container_reference"
-      ;;
-    singularity)
-      echo "Pulling Singularity image: $cap_container_reference"
-      singularity pull docker://"$cap_container_reference"
-      ;;
-    *)
-      echo "Error: Invalid cap_container_type '$cap_container_type'. Use 'docker' or 'singularity'."
-      exit 1
-      ;;
-  esac
-  )
-fi
-  }
+        case "$cap_container_type" in
+          docker)
+            echo "Pulling Docker image: $cap_container_reference"
+            docker pull "$cap_container_reference"
+            ;;
+          singularity)
+            echo "Pulling Singularity image: $cap_container_reference"
+            singularity pull docker://"$cap_container_reference"
+            ;;
+          *)
+            echo "Error: Invalid cap_container_type '$cap_container_type'. Use 'docker' or 'singularity'."
+            exit 1
+            ;;
+        esac
+      )
+  fi
+}
 
 cap_container_parse_commandline_parameters() {
   # Set default values for the named parameters

--- a/lib/functions/cap_container.sh
+++ b/lib/functions/cap_container.sh
@@ -37,36 +37,31 @@ fi
   }
 
 cap_container_parse_commandline_parameters() {
-  # Define the named commandline options
-  if ! OPTIONS=$(getopt -o "" --long container-type: -- "$@"); then
-    echo "See CAPTURE help for cap_container." >&2
-    exit 1
-  fi
-  eval set -- "$OPTIONS"
-
   # Set default values for the named parameters
-  # shellcheck disable=SC2153
   cap_container_type="${CAP_CONTAINER_TYPE}"
 
-  # Parse the optional named command line options
-  while true; do
-    case "$1" in
-      --container-type)
-        cap_container_type="$2"
-        shift 2 ;;
-      --)
-        shift
-        break;;
+  # Parse the optional named command-line options
+  while getopts "c:" opt; do
+    case "$opt" in
+      c)
+        cap_container_type="$OPTARG"
+        ;;
+      *)
+        echo "Usage: cap_container [options] reference" >&2
+        echo "See CAPTURE help for cap_container" >&2
+        exit 1
+        ;;
     esac
   done
+  shift $((OPTIND - 1))
 
-  # Check that the required file url parameter was provided
+  # Check that the required reference parameter was provided
   if [ "$#" -ne 1 ]; then
     echo "Error: incorrect number of parameters" >&2
     echo "Usage: cap_container [options] reference" >&2
     echo "See CAPTURE help for cap_container" >&2
     exit 1
   fi
+
   cap_container_reference=$1
 }
-

--- a/lib/functions/cap_container.sh
+++ b/lib/functions/cap_container.sh
@@ -45,7 +45,7 @@ cap_container_parse_commandline_parameters() {
   eval set -- "$OPTIONS"
 
   # Set default values for the named parameters
-  # shellcheck disable=SC1091
+  # shellcheck disable=SC2153
   cap_container_type="${CAP_CONTAINER_TYPE}"
 
   # Parse the optional named command line options

--- a/lib/functions/cap_container.sh
+++ b/lib/functions/cap_container.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+cap_container() {
+  cap_container_parse_commandline_parameters "$@"
+
+  sif_file=$cap_container_reference
+  sif_file="${sif_file##*/}"
+  sif_file="${sif_file/:/_}.sif"
+
+  # Check if the file exists in CAP_CONTAINER_PATH
+if [[ -f "$CAP_CONTAINER_PATH/$sif_file" ]]; then
+    echo "The $sif_file is already available"
+    exit 1
+else
+  (
+  cd "${CAP_CONTAINER_PATH}" || {
+    "Error: Unable to CD to $CAP_CONTAINER_PATH"
+    exit 1
+  }
+
+  case "$cap_container_type" in
+    docker)
+      echo "Pulling Docker image: $cap_container_reference"
+      docker pull "$cap_container_reference"
+      ;;
+    singularity)
+      echo "Pulling Singularity image: $cap_container_reference"
+      singularity pull docker://"$cap_container_reference"
+      ;;
+    *)
+      echo "Error: Invalid cap_container_type '$cap_container_type'. Use 'docker' or 'singularity'."
+      exit 1
+      ;;
+  esac
+  )
+fi
+  }
+
+cap_container_parse_commandline_parameters() {
+  # Define the named commandline options
+  if ! OPTIONS=$(getopt -o "" --long container-type: -- "$@"); then
+    echo "See CAPTURE help for cap_container." >&2
+    exit 1
+  fi
+  eval set -- "$OPTIONS"
+
+  # Set default values for the named parameters
+  # shellcheck disable=SC1091
+  cap_container_type="${CAP_CONTAINER_TYPE}"
+
+  # Parse the optional named command line options
+  while true; do
+    case "$1" in
+      --container-type)
+        cap_container_type="$2"
+        shift 2 ;;
+      --)
+        shift
+        break;;
+    esac
+  done
+
+  # Check that the required file url parameter was provided
+  if [ "$#" -ne 1 ]; then
+    echo "Error: incorrect number of parameters" >&2
+    echo "Usage: cap_container [options] reference" >&2
+    echo "See CAPTURE help for cap_container" >&2
+    exit 1
+  fi
+  cap_container_reference=$1
+}
+

--- a/tests/fixtures/lib/functions/cap_container/image_tag.sif
+++ b/tests/fixtures/lib/functions/cap_container/image_tag.sif
@@ -1,0 +1,1 @@
+some text

--- a/tests/lib/functions/test_cap_container.bats
+++ b/tests/lib/functions/test_cap_container.bats
@@ -12,12 +12,12 @@ teardown() {
   rm -rf "${CAP_CONTAINER_PATH}"
 }
 
-@test "cap_container: setting --container-type to singularity" {
+@test "cap_container: setting -c to singularity" {
 CAP_CONTAINER_TYPE="singularity"
 
 stub singularity "pull docker://base/image:tag : cp ${CONTAINER_FIXTURE_PATH}/image_tag.sif ${CAP_CONTAINER_PATH}/image_tag.sif"
 
-run cap_container --container-type "singularity" "base/image:tag"
+run cap_container -c "singularity" "base/image:tag"
 
 unstub singularity
 
@@ -32,7 +32,7 @@ diff "${CONTAINER_FIXTURE_PATH}/image_tag.sif" "${CAP_CONTAINER_PATH}/image_tag.
 
   cp "${CONTAINER_FIXTURE_PATH}/image_tag.sif" "${CAP_CONTAINER_PATH}/image_tag.sif"
 
-  run cap_container --container-type "singularity" "base/image:tag"
+  run cap_container -c "singularity" "base/image:tag"
 
   [ "$status" -eq "1" ]
   [ "$output" == "The image_tag.sif is already available" ]

--- a/tests/lib/functions/test_cap_container.bats
+++ b/tests/lib/functions/test_cap_container.bats
@@ -13,15 +13,15 @@ teardown() {
 }
 
 @test "cap_container: setting -c to singularity" {
-CAP_CONTAINER_TYPE="singularity"
+  CAP_CONTAINER_TYPE="singularity"
 
-stub singularity "pull docker://base/image:tag : cp ${CONTAINER_FIXTURE_PATH}/image_tag.sif ${CAP_CONTAINER_PATH}/image_tag.sif"
+  stub singularity "pull docker://base/image:tag : cp ${CONTAINER_FIXTURE_PATH}/image_tag.sif ${CAP_CONTAINER_PATH}/image_tag.sif"
 
-run cap_container -c "singularity" "base/image:tag"
+  run cap_container -c "singularity" "base/image:tag"
 
-unstub singularity
+  unstub singularity
 
-diff "${CONTAINER_FIXTURE_PATH}/image_tag.sif" "${CAP_CONTAINER_PATH}/image_tag.sif"
+  diff "${CONTAINER_FIXTURE_PATH}/image_tag.sif" "${CAP_CONTAINER_PATH}/image_tag.sif"
 
   [ "$status" -eq "0" ]
   [ "$output" == "Pulling Singularity image: base/image:tag" ]

--- a/tests/lib/functions/test_cap_container.bats
+++ b/tests/lib/functions/test_cap_container.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+load ../../../node_modules/bats-mock/stub
+
+source "lib/functions/cap_container.sh"
+
+setup() {
+  CAP_CONTAINER_PATH=$(mktemp -d -p "${BATS_TMPDIR}")
+  CONTAINER_FIXTURE_PATH=$(realpath "tests/fixtures/lib/functions/cap_container")
+}
+
+teardown() {
+  rm -rf "${CAP_CONTAINER_PATH}"
+}
+
+@test "cap_container: setting --container-type to singularity" {
+CAP_CONTAINER_TYPE="singularity"
+
+stub singularity "pull docker://base/image:tag : cp ${CONTAINER_FIXTURE_PATH}/image_tag.sif ${CAP_CONTAINER_PATH}/image_tag.sif"
+
+run cap_container --container-type "singularity" "base/image:tag"
+
+unstub singularity
+
+diff "${CONTAINER_FIXTURE_PATH}/image_tag.sif" "${CAP_CONTAINER_PATH}/image_tag.sif"
+
+  [ "$status" -eq "0" ]
+  [ "$output" == "Pulling Singularity image: base/image:tag" ]
+}
+
+@test "cap_container: Check for sif file" {
+  CAP_CONTAINER_TYPE="singularity"
+
+  cp "${CONTAINER_FIXTURE_PATH}/image_tag.sif" "${CAP_CONTAINER_PATH}/image_tag.sif"
+
+  run cap_container --container-type "singularity" "base/image:tag"
+
+  [ "$status" -eq "1" ]
+  [ "$output" == "The image_tag.sif is already available" ]
+}


### PR DESCRIPTION
The cap_container function will download the provided Docker reference image from DockerHub.  If the docker image is already locally available, nothing will happen. If you use the option `-c "singularity"`, then cap_container will use `singularity pull` instead of `docker pull`.  The downloaded .sif file will be saved in `CAP_CONTAINER_PATH`. 

Setup:
```
cd ~/bin/capture
git checkout main
git pull
git checkout cap-container
source ./configure.sh
source ~/.bash_profile
```

Testing:

Test cap_container on cheaha with `-c "singularity". For example:
```
#!/bin/bash

#SBATCH --nodes=1
#SBATCH --ntasks=1  
#SBATCH --cpus-per-task=2
#SBATCH --mem-per-cpu=4G
#SBATCH --partition=short

REFERENCE="tchowton/pkd_fnd_cross_species:1.0.1"

cap_container -c "singularity" "${REFERENCE}"

echo "done"

```
Resetting environment:
```
cap update
```