### PR TITLE
Rename bin/docker to bin/container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## CAPTURE 0.7.1 (March 25, 2024) ##
+
+* Renamed bin/docker to bin/container
+
 ## CAPTURE 0.7.0 (March 21, 2024) ##
 
 * Add the `cap_container` job helper function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
-## CAPTURE 0.7.1 (March 25, 2024) ##
+## CAPTURE 0.7.1 (March 25, 2025) ##
 
 * Renamed bin/docker to bin/container
 
-## CAPTURE 0.7.0 (March 21, 2024) ##
+## CAPTURE 0.7.0 (March 21, 2025) ##
 
 * Add the `cap_container` job helper function.
 
-## CAPTURE 0.6.1 (March 21, 2024) ##
+## CAPTURE 0.6.1 (March 21, 2025) ##
 
 * Add `--subdirectory` option to `cap_data_download`
 
-## CAPTURE 0.6.0 (March 20, 2024) ##
+## CAPTURE 0.6.0 (March 20, 2025) ##
 
 * Add `--normalize` option to `cap md5`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## CAPTURE 0.7.1 (March 25, 2025) ##
-
-* Renamed bin/docker to bin/container
+## CAPTURE 0.8.0 (March 25, 2025) ##
+:warning: **WARNING** This is a breaking change!
+* Rename bin/docker to bin/container. `CAP_CONTAINER_PATH` now references
+`CAP_PROJECT_PATH/bin/container` so files previously saved in bin/docker will
+need to be moved to bin/container
 
 ## CAPTURE 0.7.0 (March 21, 2025) ##
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example:
 $ cap env
 
 CAP_CONDA_PATH=/data/user/acrumley/3xtg-repurposing/bin/conda
-CAP_CONTAINER_PATH=/data/user/acrumley/3xtg-repurposing/bin/docker
+CAP_CONTAINER_PATH=/data/user/acrumley/3xtg-repurposing/bin/container
 CAP_DATA_PATH=/data/user/acrumley/3xtg-repurposing/data
 CAP_ENV=default
 CAP_LOGS_PATH=/data/user/acrumley/3xtg-repurposing/logs
@@ -304,7 +304,7 @@ provide an option for environment such as `cap run --environment=mylab foo.sh`.
 - **CAP_RESULTS_PATH**: Path to where analysis results will be written.
 Defaults to `<project-path>/results`.
 - **CAP_CONTAINER_PATH**: Path to where container files such as Docker will be
-maintained.  Defaults to `<project-path>/bin/docker`.
+maintained.  Defaults to `<project-path>/bin/container`.
 - **CAP_CONDA_PATH**: Path to where conda files will be maintained.  Defaults
 to `<project-path>/bin/conda`.
 - **CAP_RANDOM_SEED**: A randomly generated seed to facilitate reproducible

--- a/commands/env.sh
+++ b/commands/env.sh
@@ -22,7 +22,7 @@ cap_env_help() {
     $ cap env
 
     CAP_CONDA_PATH=/data/user/acrumley/3xtg-repurposing/bin/conda
-    CAP_CONTAINER_PATH=/data/user/acrumley/3xtg-repurposing/bin/docker
+    CAP_CONTAINER_PATH=/data/user/acrumley/3xtg-repurposing/bin/container
     CAP_DATA_PATH=/data/user/acrumley/3xtg-repurposing/data
     CAP_ENV=default
     CAP_LOGS_PATH=/data/user/acrumley/3xtg-repurposing/logs

--- a/commands/new.sh
+++ b/commands/new.sh
@@ -124,8 +124,8 @@ cap_new_add_dockerfile_file() {
   temporary_file=$(mktemp)
   sed \
     -e "s/{{bioconductor_version}}/${latest_release}/g" \
-    bin/docker/Dockerfile > "$temporary_file"
-  mv "$temporary_file" bin/docker/Dockerfile
+    bin/container/Dockerfile > "$temporary_file"
+  mv "$temporary_file" bin/container/Dockerfile
 }
 
 cap_new_add_pipeline_config_file() {

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -51,7 +51,7 @@ fi
 CAP_LOGS_PATH=$(realpath "logs")
 CAP_DATA_PATH=$(realpath "data")
 CAP_RESULTS_PATH=$(realpath "results")
-CAP_CONTAINER_PATH=$(realpath "bin/docker")
+CAP_CONTAINER_PATH=$(realpath "bin/container")
 CAP_CONDA_PATH=$(realpath "bin/conda")
 
 # Set all default values

--- a/tests/commands/new_bioconductor.bats
+++ b/tests/commands/new_bioconductor.bats
@@ -14,7 +14,7 @@ load ../../node_modules/bats-mock/stub
     unstub curl
 
     # Check that the version was updated.
-    run grep -o "RELEASE_3_20-CAPTURE" $BATS_TMPDIR/test/bin/docker/Dockerfile
+    run grep -o "RELEASE_3_20-CAPTURE" $BATS_TMPDIR/test/bin/container/Dockerfile
 
     # Clean up the test project.
     rm -rf $BATS_TMPDIR/test


### PR DESCRIPTION
I renamed bin/docker for clarity because capture and cap_container can work with singularity containers as well as docker containers. Please test the cap_container function and cap new.

The cap_container function will download the provided Docker reference image from DockerHub. If the docker image is already locally available, nothing will happen. If you use the option -c "singularity", then cap_container will use singularity pull instead of docker pull. The downloaded .sif file will be saved in CAP_CONTAINER_PATH.

Setup:

```
cd ~/bin/capture
git checkout main
git pull
cd project-template
git checkout main
git pull
cd ../
git checkout rename-docker-dir
source ./configure.sh
source ~/.bash_profile
```

Testing:

Test cap_container on cheaha with `-c "singularity". For example:
```
#!/bin/bash

#SBATCH --nodes=1
#SBATCH --ntasks=1  
#SBATCH --cpus-per-task=2
#SBATCH --mem-per-cpu=4G
#SBATCH --partition=short

REFERENCE="tchowton/pkd_fnd_cross_species:1.0.1"

cap_container -c "singularity" "${REFERENCE}"

echo "done"
```
Resetting environment:
```
cap update
```
Test:
Create a new project in your projects or scratch directory and check that the bin/container/Dockerfile file has the latest version of Bioconductor. The first line should look something like the following:

FROM bioconductor/bioconductor_docker:RELEASE_3_20-R-4.4.2