### PR TITLE
Prevent script exit when a container exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## CAPTURE 0.8.1 (April 18, 2025) ##
+
+* Prevent script exist whan a `cap_container` container exists
+
 ## CAPTURE 0.8.0 (March 25, 2025) ##
 :warning: **WARNING** This is a breaking change!
 * Rename bin/docker to bin/container. `CAP_CONTAINER_PATH` now references

--- a/lib/functions/cap_container.sh
+++ b/lib/functions/cap_container.sh
@@ -10,7 +10,6 @@ cap_container() {
   # Check if the file exists in CAP_CONTAINER_PATH
   if [[ -f "$CAP_CONTAINER_PATH/$sif_file" ]]; then
     echo "The $sif_file is already available"
-    exit 1
   else
     (
     cd "${CAP_CONTAINER_PATH}" || {


### PR DESCRIPTION
When a container already exists, cap_container terminates the script execution when it should just output a message and continue.

# Setup:

```
cd ~/bin/capture
git checkout main
git pull
git checkout cap-container-exists

```

# Testing:

Test cap_container on cheaha in a new project by running the following script twice with `cap run`:

```
#!/bin/bash

#SBATCH --ntasks=1
#SBATCH --time=24:00:00
#SBATCH --mem-per-cpu=16G
#SBATCH --partition=medium

cap_container -c singularity "ncbi/sra-tools:3.2.1"

echo "Keeps going when the container exists."
```
The first run should produce a `.out` file with something like the following.
```
Pulling Singularity image: ncbi/sra-tools:3.2.1
Keeps going when the container exists.
```
The second run should produce a `.out` file with something like the following.
```
The sra-tools_3.2.1.sif is already available
Keeps going when the container exists.

```
# Resetting environment:
```
cap update

```