### PR TITLE
Fix GitHub tests

### DIFF
--- a/.github/workflows/bats-tests.yml
+++ b/.github/workflows/bats-tests.yml
@@ -16,11 +16,13 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v4
 
-      - name: Set up BATS
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y bats
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
-      - name: Run BATS tests
-        run: bats -r tests/
+      - name: Install dependencies
+        run: npm install
 
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/bats-tests.yml
+++ b/.github/workflows/bats-tests.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/bats-tests.yml
+++ b/.github/workflows/bats-tests.yml
@@ -22,5 +22,5 @@ jobs:
           sudo apt-get install -y bats
 
       - name: Run BATS tests
-        run: bats tests/
+        run: bats -r tests/
 

--- a/tests/commands/md5.bats
+++ b/tests/commands/md5.bats
@@ -12,7 +12,7 @@ teardown() {
 }
 
 @test "cap md5: All files in a folder" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     cap md5 -o $temp_output $FIXTURE_PATH/files
     run diff $temp_output $FIXTURE_PATH/outputs/all.out
 
@@ -21,7 +21,7 @@ teardown() {
 }
 
 @test "cap md5: A specific file" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     cap md5 -o $temp_output $FIXTURE_PATH/files/one.bin
     run diff $temp_output $FIXTURE_PATH/outputs/one.out
 
@@ -30,7 +30,7 @@ teardown() {
 }
 
 @test "cap md5: Two specific files" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     cap md5 -o $temp_output $FIXTURE_PATH/files/one.bin $FIXTURE_PATH/files/two.bin
     run diff $temp_output $FIXTURE_PATH/outputs/one_two.out
 
@@ -39,7 +39,7 @@ teardown() {
 }
 
 @test "cap md5: --select a file in subdirectories" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     cap md5 --select "*/three.bin" -o $temp_output $FIXTURE_PATH/files
     run diff $temp_output $FIXTURE_PATH/outputs/three.out
 
@@ -48,7 +48,7 @@ teardown() {
 }
 
 @test "cap md5: --select a directory in subdirectories" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     cap md5 --select "*/outs/*" -o $temp_output $FIXTURE_PATH/files
     run diff $temp_output $FIXTURE_PATH/outputs/three_four.out
 
@@ -57,7 +57,7 @@ teardown() {
 }
 
 @test "cap md5: --select two files in subdirectories" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     cap md5 --select "*/three.bin" --select "*/four.bin" -o $temp_output $FIXTURE_PATH/files
     run diff $temp_output $FIXTURE_PATH/outputs/three_four.out
 
@@ -66,7 +66,7 @@ teardown() {
 }
 
 @test "cap md5: --ignore a file in subdirectories" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     cap md5 --ignore "*/three.bin" -o $temp_output $FIXTURE_PATH/files
     run diff $temp_output $FIXTURE_PATH/outputs/one_two_four.out
 
@@ -75,7 +75,7 @@ teardown() {
 }
 
 @test "cap md5: --ignore a directory in subdirectories" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     cap md5 --ignore "*/outs/*" -o $temp_output $FIXTURE_PATH/files
     run diff $temp_output $FIXTURE_PATH/outputs/one_two.out
 
@@ -84,7 +84,7 @@ teardown() {
 }
 
 @test "cap md5: --ignore two files in subdirectories" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     cap md5 --ignore "*/one.bin" --ignore "*/two.bin" -o $temp_output $FIXTURE_PATH/files
     run diff $temp_output $FIXTURE_PATH/outputs/three_four.out
 
@@ -94,7 +94,7 @@ teardown() {
 
 @test "cap md5 --slurm batch: All files in a folder" {
 
-    temp_script=$(mktemp -p "$BATS_TEMPDIR")
+    temp_script=$(mktemp -p "$BATS_TMPDIR")
     stub mktemp " : echo '$temp_script'"
     stub sbatch "$temp_script : echo 'sbatch called correctly'"
     run cap md5 --slurm batch -o "test/output.txt" $FIXTURE_PATH/files
@@ -123,7 +123,7 @@ EOF
 
 @test "cap md5 --slurm batch: Two specific files" {
 
-    temp_script=$(mktemp -p "$BATS_TEMPDIR")
+    temp_script=$(mktemp -p "$BATS_TMPDIR")
     stub mktemp " : echo '$temp_script'"
     stub sbatch "$temp_script : echo 'sbatch called correctly'"
     run cap md5 --slurm batch -o "test/output.txt" $FIXTURE_PATH/files/one.bin $FIXTURE_PATH/files/two.bin
@@ -152,7 +152,7 @@ EOF
 
 @test "cap md5 --slurm batch: --select a directory in subdirectories" {
 
-    temp_script=$(mktemp -p "$BATS_TEMPDIR")
+    temp_script=$(mktemp -p "$BATS_TMPDIR")
     stub mktemp " : echo '$temp_script'"
     stub sbatch "$temp_script : echo 'sbatch called correctly'"
     run cap md5 --select "*/outs/*" --slurm batch -o "test/output.txt" $FIXTURE_PATH/files
@@ -181,7 +181,7 @@ EOF
 
 @test "cap md5 --slurm batch: --ignore a directory in subdirectories" {
 
-    temp_script=$(mktemp -p "$BATS_TEMPDIR")
+    temp_script=$(mktemp -p "$BATS_TMPDIR")
     stub mktemp " : echo '$temp_script'"
     stub sbatch "$temp_script : echo 'sbatch called correctly'"
     run cap md5 --ignore "*/outs/*" --slurm batch -o "test/output.txt" $FIXTURE_PATH/files
@@ -209,7 +209,7 @@ EOF
 }
 
 @test "cap md5 --slurm run: All files in a folder" {
-    temp_script=$(mktemp -p "$BATS_TEMPDIR")
+    temp_script=$(mktemp -p "$BATS_TMPDIR")
     stub mktemp " : echo '$temp_script'"
     stub srun "--job-name=cap-md5 --ntasks=1 --cpus-per-task=1 --mem=32G --output=/dev/stdout --input=$temp_script --export=ALL bash : echo 'srun called correctly'"
     run cap md5 --slurm "run" $FIXTURE_PATH/files
@@ -226,7 +226,7 @@ EOF
 }
 
 @test "cap md5 --slurm run: Two specific files" {
-    temp_script=$(mktemp -p "$BATS_TEMPDIR")
+    temp_script=$(mktemp -p "$BATS_TMPDIR")
     stub mktemp " : echo '$temp_script'"
     stub srun "--job-name=cap-md5 --ntasks=1 --cpus-per-task=1 --mem=32G --output=/dev/stdout --input=$temp_script --export=ALL bash : echo 'srun called correctly'"
     run cap md5 --slurm "run" $FIXTURE_PATH/files/one.bin $FIXTURE_PATH/files/two.bin
@@ -243,7 +243,7 @@ EOF
 }
 
 @test "cap md5 --slurm run: --select a directory in subdirectories" {
-    temp_script=$(mktemp -p "$BATS_TEMPDIR")
+    temp_script=$(mktemp -p "$BATS_TMPDIR")
     stub mktemp " : echo '$temp_script'"
     stub srun "--job-name=cap-md5 --ntasks=1 --cpus-per-task=1 --mem=32G --output=/dev/stdout --input=$temp_script --export=ALL bash : echo 'srun called correctly'"
     run cap md5 --select "*/outs/*" --slurm "run" $FIXTURE_PATH/files
@@ -260,7 +260,7 @@ EOF
 }
 
 @test "cap md5 --slurm run: --ignore a directory in subdirectories" {
-    temp_script=$(mktemp -p "$BATS_TEMPDIR")
+    temp_script=$(mktemp -p "$BATS_TMPDIR")
     stub mktemp " : echo '$temp_script'"
     stub srun "--job-name=cap-md5 --ntasks=1 --cpus-per-task=1 --mem=32G --output=/dev/stdout --input=$temp_script --export=ALL bash : echo 'srun called correctly'"
     run cap md5 --ignore "*/outs/*" --slurm "run" $FIXTURE_PATH/files
@@ -277,7 +277,7 @@ EOF
 }
 
 @test "cap md5: Process symlink subdirectories" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     mkdir "$CAP_DATA_PATH/output"
     ln -s $(realpath $FIXTURE_PATH/files) $CAP_DATA_PATH/output/files
     cap md5 -o $temp_output $CAP_DATA_PATH/output
@@ -290,7 +290,7 @@ EOF
 }
 
 @test "cap md5: Process symlink command line arguments" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     ln -s $(realpath $FIXTURE_PATH/files) $CAP_DATA_PATH/files
     cap md5 -o $temp_output $CAP_DATA_PATH/files
     run diff -u \
@@ -302,7 +302,7 @@ EOF
 }
 
 @test "cap md5 --normalize: All files in a folder" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     cap md5 --normalize -o $temp_output $FIXTURE_PATH/files
     run diff $temp_output $FIXTURE_PATH/outputs/all_normalized.out
 
@@ -311,7 +311,7 @@ EOF
 }
 
 @test "cap md5 --normalize: Only one file" {
-    temp_output=$(mktemp -p "$BATS_TEMPDIR")
+    temp_output=$(mktemp -p "$BATS_TMPDIR")
     cap md5 --normalize --select "*one.bin" -o $temp_output $FIXTURE_PATH/files
     run diff $temp_output $FIXTURE_PATH/outputs/one_normalized.out
 

--- a/tests/commands/run.bats
+++ b/tests/commands/run.bats
@@ -21,7 +21,7 @@ teardown() {
 
   cp "$FIXTURE_PATH/job.sh" "$PROJECTS_PATH/test/src"
   cd "$PROJECTS_PATH/test"
-  temp_script="$(mktemp -p "$BATS_TEMPDIR")"
+  temp_script="$(mktemp -p "$BATS_TMPDIR")"
   stub mktemp " : echo '$temp_script'"
   sbatch_parameters=(
     -D=src
@@ -54,7 +54,7 @@ EOF
 @test "cap run: Dry run with default environment" {
   cp "$FIXTURE_PATH/job.sh" "$PROJECTS_PATH/test/src"
   cd "$PROJECTS_PATH/test"
-  temp_script="$(mktemp -p "$BATS_TEMPDIR")"
+  temp_script="$(mktemp -p "$BATS_TMPDIR")"
   stub date "+%Y%m%d_%H%M%S : echo '20250324_132703'"
   run cap run -n src/job.sh
   unstub date
@@ -106,7 +106,7 @@ EOF
 @test "cap run: Dry run with environment option specified" {
   cp "$FIXTURE_PATH/job.sh" "$PROJECTS_PATH/test/src"
   cd "$PROJECTS_PATH/test"
-  temp_script="$(mktemp -p "$BATS_TEMPDIR")"
+  temp_script="$(mktemp -p "$BATS_TMPDIR")"
   stub date "+%Y%m%d_%H%M%S : echo '20250324_132703'"
   run cap run -n -e test src/job.sh
   unstub date

--- a/tests/commands/run.bats
+++ b/tests/commands/run.bats
@@ -26,7 +26,7 @@ teardown() {
   sbatch_parameters=(
     -D=src
     --job-name=job-test
-    --output=$PROJECTS_PATH/test/logs/job_20250324_132703_$(whoami).out
+    --output=$PROJECTS_PATH/test/logs/job_20250324_132703_crumley.out
     --error=$PROJECTS_PATH/test/logs/job_20250324_132703_$(whoami).err
     $temp_script
   )

--- a/tests/commands/run.bats
+++ b/tests/commands/run.bats
@@ -71,6 +71,7 @@ CAP_CONDA_PATH=$PROJECTS_PATH/test/bin/conda
 CAP_CONTAINER_PATH=$PROJECTS_PATH/test/bin/container
 CAP_CONTAINER_TYPE=docker
 CAP_DATA_PATH=$PROJECTS_PATH/test/data
+CAP_DEVELOPMENT_PATH=$CAP_DEVELOPMENT_PATH
 CAP_ENV=default
 CAP_ETC_RC_PATH=$CAP_ETC_RC_PATH
 CAP_HOME_RC_PATH=$CAP_HOME_RC_PATH
@@ -89,7 +90,7 @@ Job: job
      5  #SBATCH --cpus-per-task=1
      6  #SBATCH --time=24:00:00
      7  #SBATCH --partition=medium
-     8  source /home/$(whoami)/bin/capture/lib/functions.sh
+     8  source $CAP_DEVELOPMENT_PATH/lib/functions.sh
      9
     10
     11  echo "Hello world!"
@@ -122,6 +123,7 @@ CAP_CONDA_PATH=$PROJECTS_PATH/test/bin/conda
 CAP_CONTAINER_PATH=$PROJECTS_PATH/test/bin/container
 CAP_CONTAINER_TYPE=docker
 CAP_DATA_PATH=$PROJECTS_PATH/test/data
+CAP_DEVELOPMENT_PATH=$CAP_DEVELOPMENT_PATH
 CAP_ENV=test
 CAP_ETC_RC_PATH=$CAP_ETC_RC_PATH
 CAP_HOME_RC_PATH=$CAP_HOME_RC_PATH
@@ -140,7 +142,7 @@ Job: job
      5  #SBATCH --cpus-per-task=1
      6  #SBATCH --time=24:00:00
      7  #SBATCH --partition=medium
-     8  source /home/$(whoami)/bin/capture/lib/functions.sh
+     8  source $CAP_DEVELOPMENT_PATH/lib/functions.sh
      9
     10
     11  echo "Hello world!"

--- a/tests/commands/run.bats
+++ b/tests/commands/run.bats
@@ -26,7 +26,7 @@ teardown() {
   sbatch_parameters=(
     -D=src
     --job-name=job-test
-    --output=$PROJECTS_PATH/test/logs/job_20250324_132703_crumley.out
+    --output=$PROJECTS_PATH/test/logs/job_20250324_132703_$(whoami).out
     --error=$PROJECTS_PATH/test/logs/job_20250324_132703_$(whoami).err
     $temp_script
   )

--- a/tests/lib/functions/test_cap_container.bats
+++ b/tests/lib/functions/test_cap_container.bats
@@ -34,6 +34,6 @@ teardown() {
 
   run cap_container -c "singularity" "base/image:tag"
 
-  [ "$status" -eq "1" ]
+  [ "$status" -eq "0" ]
   [ "$output" == "The image_tag.sif is already available" ]
 }

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -8,8 +8,20 @@ setup_suite() {
   CAP_DEVELOPMENT_PATH="$(pwd)"
   export CAP_DEVELOPMENT_PATH
 
-  CAP_ETC_RC_PATH="$(mktemp -p "$BATS_TEMPDIR")"
+  # Setup a unique temporary directory for BATS tests to fix temporary file
+  # errors on Cheaha where developers share temp directories.
+  BATS_TMPDIR="$(mktemp -d)"
+  export BATS_TMPDIR
+
+  # Setup test locations for caprc files.  Otherwise, the developer's actual
+  # caprc files will be used and make tests fail.
+  CAP_ETC_RC_PATH="$(mktemp -p "$BATS_TMPDIR")"
   export CAP_ETC_RC_PATH
-  CAP_HOME_RC_PATH="$(mktemp -p "$BATS_TEMPDIR")"
+  CAP_HOME_RC_PATH="$(mktemp -p "$BATS_TMPDIR")"
   export CAP_HOME_RC_PATH
+}
+
+teardown_suite() {
+  # Remove the unique temporary directory created in setup_suite().
+  rm -rf "$BATS_TMPDIR"
 }

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -4,6 +4,10 @@ setup_suite() {
   PATH="$(pwd):$PATH"
   export PATH
 
+  # Location of the CAPTURE framework development environment.
+  CAP_DEVELOPMENT_PATH="$(pwd)"
+  export CAP_DEVELOPMENT_PATH
+
   CAP_ETC_RC_PATH="$(mktemp -p "$BATS_TEMPDIR")"
   export CAP_ETC_RC_PATH
   CAP_HOME_RC_PATH="$(mktemp -p "$BATS_TEMPDIR")"


### PR DESCRIPTION
The BATS bash tests were not running properly on Github because the command being used was not running the tests recursively.  To correct the problem, the Github workflow was changed to use the `npm test` command.  This causes tests to be ran recursively and aligns test execution on Github with how it is done on Cheaha.

# Setup and testing:

```
cd ~/bin/capture
git checkout main
git pull
git checkout github-tests
npm install
npm test

```
The last of the test output should look like the following screenshot with `0 failures`.

![Screenshot 2025-04-30 at 3 36 42 PM](https://github.com/user-attachments/assets/28166119-75cc-4ab5-9b9f-7bd02009dd02)

Once the tests run correctly locally, a new branch should be created with a corresponding pull request to make sure the tests run correctly on GitHub.

```
git checkout -b "$USER-test"
git push origin "$USER-test"

```
Create a pull request and verify the tests run on Github under the actions tab.  The results should look something like the following with all 45 of the tests having an `ok` result.
<img width="1508" alt="Screenshot 2025-05-05 at 2 53 34 PM" src="https://github.com/user-attachments/assets/c8ecad91-83cf-4704-8796-11e46291e788" />


 Next, close the pull request, delete the branch on Github, and delete the branch locally with the following commands.
``` 
git checkout github-tests
git branch -d "$USER-test"

```
# Resetting environment:
```
cap update

```