### PR TITLE
Add requirement for user to supply a tag for the dockerhub reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## CAPTURE 0.8.2 (May 7, 2025) ##
+* `cap_container` requires a tag to be provided in the REFERENCE.
+
 ## CAPTURE 0.8.1 (April 18, 2025) ##
 
 * Prevent script exist whan a `cap_container` container exists

--- a/lib/functions/cap_container.sh
+++ b/lib/functions/cap_container.sh
@@ -4,6 +4,18 @@ cap_container() {
   cap_container_parse_commandline_parameters "$@"
 
   sif_file=$cap_container_reference
+
+  # Check that the format of the provided reference is correct
+  if [[ ! "$sif_file" =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+:.+ ]]; then
+    echo "Error: REFERENCE must be in the format <namespace>/<repository>:<tag>"
+    exit 1
+  fi
+
+  # Check if tag is 'latest'
+  if [[ "${sif_file##*:}" == "latest" ]]; then
+    echo "Warning: Please provide a specific tag instead of 'latest' to ensure reproducibility."
+  fi
+
   sif_file="${sif_file##*/}"
   sif_file="${sif_file/:/_}.sif"
 

--- a/tests/fixtures/lib/functions/cap_container/image_latest.sif
+++ b/tests/fixtures/lib/functions/cap_container/image_latest.sif
@@ -1,0 +1,1 @@
+some text

--- a/tests/lib/functions/test_cap_container.bats
+++ b/tests/lib/functions/test_cap_container.bats
@@ -37,3 +37,33 @@ teardown() {
   [ "$status" -eq "1" ]
   [ "$output" == "The image_tag.sif is already available" ]
 }
+
+@test "cap_container: Check for tag" {
+  CAP_CONTAINER_TYPE="singularity"
+
+  run cap_container -c "singularity" "base/image"
+
+  [ "$status" -eq "1" ]
+  [ "$output" == "Error: REFERENCE must be in the format <namespace>/<repository>:<tag>" ]
+}
+
+@test "cap_container: Check for latest tag" {
+  CAP_CONTAINER_TYPE="singularity"
+
+  stub singularity "pull docker://base/image:latest : cp ${CONTAINER_FIXTURE_PATH}/image_latest.sif ${CAP_CONTAINER_PATH}/image_latest.sif"
+
+  run cap_container -c "singularity" "base/image:latest"
+
+  unstub singularity
+
+  diff "${CONTAINER_FIXTURE_PATH}/image_latest.sif" "${CAP_CONTAINER_PATH}/image_latest.sif"
+
+  EXPECTED_OUTPUT=$(cat <<EOF
+Warning: Please provide a specific tag instead of 'latest' to ensure reproducibility.
+Pulling Singularity image: base/image:latest
+EOF
+)
+
+  [ "$status" -eq "0" ]
+  [ "$output" == "$EXPECTED_OUTPUT" ]
+}


### PR DESCRIPTION
We are requiring the user supply a tag for the dockerhub reference to improve reproducibility and eliminate an error that would occur if the user did not provide a tag and ran the script after the repository_latest.sif file was created. I also added a warning if the user uses 'latest' as a tag because it might not be completely reproducible in the future.

### Setup:
```
cd ~/bin/capture
git checkout main
git pull
git checkout cap-container-require-tag
```

### Testing:
Test cap_container on cheaha with `-c "singularity"` without providing a tag.

```
#!/bin/bash

#SBATCH --ntasks=1
#SBATCH --time=24:00:00
#SBATCH --mem-per-cpu=16G
#SBATCH --partition=medium

cap_container -c singularity "ncbi/sra-tools"

echo "Keeps going when the container exists."
```
You should get a .out file in the logs directory that says 'Error: REFERENCE must be in the format \<namespace\>/\<repository\>:\<tag\>'

---
Test cap_container on cheaha with `-c "singularity"` using 'latest' as the tag.
```
#!/bin/bash

#SBATCH --ntasks=1
#SBATCH --time=24:00:00
#SBATCH --mem-per-cpu=16G
#SBATCH --partition=medium

cap_container -c singularity "ncbi/sra-tools:latest"

echo "Keeps going when the container exists."
```
You should see a warning about using 'latest' in the .out file in /logs/ and there should be a sra-tools_latest.sif file in /bin/container/.

### Resetting environment:
```
cap update
```