### PR TITLE
Fix issue of run path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 
-## CAPTURE 0.8.3 (May 7, 2025) ##
-* `cap_container` requires a tag to be provided in the REFERENCE.
+## CAPTURE 0.8.3 (June 12, 2025) ##
+* Fixed the slurmstepd error when running `cap run`
 
 ## CAPTURE 0.8.2 (April 30, 2025) ##
 

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -103,7 +103,7 @@ EOF
   else
     temp_batch_script=$(mktemp)
     echo "$slurm_job" > "$temp_batch_script"
-    sbatch -D="$job_directory" \
+    sbatch -D "$job_directory" \
       --job-name="${job_name%.*}-$CAP_PROJECT_NAME" \
       --output="$log_full_path/$log_file_name.out" \
       --error="$log_full_path/$log_file_name.err" \

--- a/tests/commands/run.bats
+++ b/tests/commands/run.bats
@@ -24,7 +24,7 @@ teardown() {
   temp_script="$(mktemp -p "$BATS_TMPDIR")"
   stub mktemp " : echo '$temp_script'"
   sbatch_parameters=(
-    -D=src
+    -D src
     --job-name=job-test
     --output=$PROJECTS_PATH/test/logs/job_20250324_132703_$(whoami).out
     --error=$PROJECTS_PATH/test/logs/job_20250324_132703_$(whoami).err


### PR DESCRIPTION
This PR fixes this error:
slurmstepd: error: couldn't chdir to `/data/user/tchowton/wetlab-sc-atac/=src': No such file or directory: going to /tmp instead

Setup:
cd ~/bin/capture
git checkout main
git pull
git checkout fix-src-path

Testing:
Test that the file path is corrected:
```
cd $USER_SCRATCH
cap new --skip-git test-src-path
cd test-src-path
``` 

Create a bash script called submit-test-src.sh in the src directory
```
#!/bin/bash

#################################### SLURM ####################################
#SBATCH --job-name test-src
#SBATCH --ntasks=1
#SBATCH --cpus-per-task=1
#SBATCH --mem-per-cpu=8G
#SBATCH --partition=express

pwd
```
Run src/submit-test-src.sh
```
cap run -e default src/submit-test-src.sh
```
Once the run is complete, check the log files and make sure that the path is correct.

Resetting environment:
```
cd $USER_SCRATCH
rm -rf test-src-path
cap update
```