### PR TITLE
Fix slurm error for files with parentheses in name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## CAPTURE 0.8.5 (October 9, 2025) ##
+* Fix slurm error for files with parentheses in name
+
 ## CAPTURE 0.8.4 (June 12, 2025) ##
 * Change Dockerfile to Dockerfile-template
 

--- a/commands/md5.sh
+++ b/commands/md5.sh
@@ -118,7 +118,7 @@ cap_md5() {
 #SBATCH --mem-per-cpu=32G
 #SBATCH --partition=short
 
-cap md5 $slurm_args ${md5_files[@]}
+cap md5 $slurm_args "${md5_files[@]}"
 echo "Ran from: $current_path"
 EOF
       sbatch "$temp_batch_script"

--- a/tests/commands/md5.bats
+++ b/tests/commands/md5.bats
@@ -113,7 +113,7 @@ teardown() {
 #SBATCH --mem-per-cpu=32G
 #SBATCH --partition=short
 
-cap md5 -o "test/output.txt"  $FIXTURE_PATH/files
+cap md5 -o "test/output.txt"  "$FIXTURE_PATH/files"
 echo "Ran from: $(pwd)"
 EOF
 ) "$temp_script"
@@ -142,7 +142,36 @@ EOF
 #SBATCH --mem-per-cpu=32G
 #SBATCH --partition=short
 
-cap md5 -o "test/output.txt"  $FIXTURE_PATH/files/one.bin $FIXTURE_PATH/files/two.bin
+cap md5 -o "test/output.txt"  "$FIXTURE_PATH/files/one.bin $FIXTURE_PATH/files/two.bin"
+echo "Ran from: $(pwd)"
+EOF
+) "$temp_script"
+
+    [ "$output" == "sbatch called correctly" ]
+}
+
+@test "cap md5 --slurm batch: Files with parenthesis in their name" {
+
+    temp_script=$(mktemp -p "$BATS_TMPDIR")
+    stub mktemp " : echo '$temp_script'"
+    stub sbatch "$temp_script : echo 'sbatch called correctly'"
+    run cap md5 --slurm batch -o "test/output.txt" $FIXTURE_PATH/error_files/*.csv
+    unstub mktemp
+    unstub sbatch
+
+    diff <(cat <<EOF
+#!/bin/bash
+
+#################################### SLURM ####################################
+#SBATCH --job-name cap-md5
+#SBATCH --output test/output.txt
+#SBATCH --error test/output.txt
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem-per-cpu=32G
+#SBATCH --partition=short
+
+cap md5 -o "test/output.txt"  "$FIXTURE_PATH/error_files/test(1).csv"
 echo "Ran from: $(pwd)"
 EOF
 ) "$temp_script"
@@ -171,7 +200,7 @@ EOF
 #SBATCH --mem-per-cpu=32G
 #SBATCH --partition=short
 
-cap md5 --select "*/outs/*" -o "test/output.txt"  $FIXTURE_PATH/files
+cap md5 --select "*/outs/*" -o "test/output.txt"  "$FIXTURE_PATH/files"
 echo "Ran from: $(pwd)"
 EOF
 ) "$temp_script"
@@ -200,7 +229,7 @@ EOF
 #SBATCH --mem-per-cpu=32G
 #SBATCH --partition=short
 
-cap md5 --ignore "*/outs/*" -o "test/output.txt"  $FIXTURE_PATH/files
+cap md5 --ignore "*/outs/*" -o "test/output.txt"  "$FIXTURE_PATH/files"
 echo "Ran from: $(pwd)"
 EOF
 ) "$temp_script"


### PR DESCRIPTION
When files have a parentheses in the name and the --slurm=batch parameter is provided, the slurm job would error. This was caused by parentheses in the bash script created for the slurm job. To correct the problem, the file names in the bash script are now quoted.  This should fix the problem for other characters too.

# Setup instructions:
```
cd ~/bin/capture
git checkout main
git pull
git checkout fix-md5-parenthesis
```

# Test instructions:

- Create a file name with parentheses in the name, i.e.  test(1).csv.
- Run `cap md5` commands with at least the following option combinations.
    - no options
    - -n
    - -o
    - --slurm=run
    - --slurm=batch -o
    - --slurm=batch -n
    - --slurm=batch --select
    - --slurm=batch --ignore
    - Any other combinations that seem needed.

# Resetting environment:
```
cap update

```