### PR TITLE
Fix cap_container error with array jobs

### DIFF
--- a/tests/lib/functions/test_cap_container.bats
+++ b/tests/lib/functions/test_cap_container.bats
@@ -42,9 +42,7 @@ EOF
   run cap_container -c "singularity" "base/image:tag"
 
   EXPECTED_OUTPUT=$(cat <<EOF
-Lock acquired for image_tag.sif. Pulling image...
 The image_tag.sif is already available
-Lock for image_tag.sif is released.
 EOF
 )
 

--- a/tests/lib/functions/test_cap_container.bats
+++ b/tests/lib/functions/test_cap_container.bats
@@ -23,8 +23,15 @@ teardown() {
 
   diff "${CONTAINER_FIXTURE_PATH}/image_tag.sif" "${CAP_CONTAINER_PATH}/image_tag.sif"
 
+  EXPECTED_OUTPUT=$(cat <<EOF
+Lock acquired for image_tag.sif. Pulling image...
+Pulling Singularity image: base/image:tag
+Lock for image_tag.sif is released.
+EOF
+)
+
   [ "$status" -eq "0" ]
-  [ "$output" == "Pulling Singularity image: base/image:tag" ]
+  [ "$output" == "$EXPECTED_OUTPUT" ]
 }
 
 @test "cap_container: Check for sif file" {
@@ -34,8 +41,15 @@ teardown() {
 
   run cap_container -c "singularity" "base/image:tag"
 
+  EXPECTED_OUTPUT=$(cat <<EOF
+Lock acquired for image_tag.sif. Pulling image...
+The image_tag.sif is already available
+Lock for image_tag.sif is released.
+EOF
+)
+
   [ "$status" -eq "0" ]
-  [ "$output" == "The image_tag.sif is already available" ]
+  [ "$output" == "$EXPECTED_OUTPUT" ]
 }
 
 @test "cap_container: Check for tag" {
@@ -60,10 +74,32 @@ teardown() {
 
   EXPECTED_OUTPUT=$(cat <<EOF
 Warning: Please provide a specific tag instead of 'latest' to ensure reproducibility.
+Lock acquired for image_latest.sif. Pulling image...
 Pulling Singularity image: base/image:latest
+Lock for image_latest.sif is released.
 EOF
 )
 
   [ "$status" -eq "0" ]
   [ "$output" == "$EXPECTED_OUTPUT" ]
 }
+
+@test "cap_container: Wait for lock to clear on array jobs" {
+  mkdir "${CAP_CONTAINER_PATH}/image_tag.sif.lock"
+
+  stub sleep "2 : rmdir ${CAP_CONTAINER_PATH}/image_tag.sif.lock"
+
+  run cap_container -c "singularity" "base/image:tag"
+
+  unstub sleep
+
+  EXPECTED_OUTPUT=$(cat <<EOF
+Waiting for lock on container image image_tag.sif...
+Lock is released on container image image_tag.sif. Proceeding.
+EOF
+)
+
+  [ "$status" -eq "0" ]
+  [ "$output" == "$EXPECTED_OUTPUT" ]
+}
+


### PR DESCRIPTION
Array jobs run in parallel.  If the jobs call cap_container to download a Docker container errors may occur. To resolve this problem, the first job to start will create a lock directory and all subsequent jobs will wait on the lock to clear before proceeding with the script.

# Setup instructions:
```
cd ~/bin/capture
git checkout main
git pull
git checkout cap-container-array-job
npm test
```

# Test instructions:
Create a Slurm script like the following in a test CAPTURE project and execute it with `cap run`.
```
#!/bin/bash

#SBATCH --nodes=1
#SBATCH --ntasks=1
#SBATCH --mem=16G
#SBATCH --cpus-per-task=1
#SBATCH --time=01:00:00
#SBATCH --partition=express
#SBATCH --array=0-11

cap_container -c singularity "rancher/hello-world:v0.1.2"

echo "Success"
```
The log files should show messages where one job acquires a lock and downloads the container while the others wait for the lock to clear before proceeding.

# Resetting environment:
```
cap update

```