### PR TITLE
Add CAP_CONTAINER_TYPE to cap_container documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ data directory is specified by `CAP_DATA_PATH` which defaults to
 file will be saved in `CAP_PROJECT_PATH/data/subdirectory`.
 
 If the file or directory already exists in the `data` directory (or subdirectory
-if `--subdirectory` is provided) then it will not be downloaded again. This is 
+if `--subdirectory` is provided) then it will not be downloaded again. This is
 also true when the file or directory has been symlinked into the `data` directory
 by [cap_data_link](#cap_data_link).
 
@@ -463,16 +463,20 @@ cap_container [options] REFERENCE
 is <namespace>/<repository_name>:[tag].
 
 Options
-- `-c singularity`  If specified, cap_container will use `singularity pull` instead of `docker pull`.
+- `-c singularity`  If specified, cap_container will use `singularity pull`
+instead of `docker pull`. If `CAP_CONTAINER_TYPE` is specified in a `caprc` file
+then the -c option is not necessary. `CAP_CONTAINER_TYPE` is the preferred
+method.
 
 `cap_container` first checks whether the Docker image or Singularity .sif file
 already exists in `CAP_CONTAINER_PATH`. If the image is not found, it is downloaded
 from DockerHub. By default, `cap_container` uses Docker, but specifying the
-`-c singularity` option directs it to generate a Singularity .sif file in the
-`CAP_CONTAINER_PATH` directory instead.
+`-c singularity` option or `CAP_CONTAINER_TYPE=singularity` in a `caprc`
+directs it to generate a Singularity .sif file in the `CAP_CONTAINER_PATH`
+directory instead.
 
 The following example checks for the corresponding .sif file in `CAP_CONTAINER_PATH`.
-If the file is not found, it downloads and converts the Docker image into the 
+If the file is not found, it downloads and converts the Docker image into the
 Singularity .sif file - ollama_0.5.8.sif.
 ```
 cap_container \


### PR DESCRIPTION
## Summary
<!-- Describe the change -->
Add CAP_CONTAINER_TYPE to cap_container documentation so users realize it can be set in a caprc instead of using the -c option for container types other than Docker.

## Author Checklist
- [x] This repository has a Lasseigne Lab ruleset configured.
  See instructions [here](https://github.com/lasseignelab/project-template/blob/main/DEVELOPMENT.md).
- [x] Only files relevant to this change are included; no temporary, generated,
  or unrelated files are part of this pull request. Use `.gitignore` to prevent
  irrelevant files from accidentally being included.
- [x] All automated tests have passed.
- [x] All automated code checks have passed. The "All checks have passed"
  message should show in the GitHub pull request status box above the
  "Merge pull request" button.
- [x] No merge conflicts exist. Merge conflicts are indicated by the "This
  branch has conflicts that must be resolved" message in the GitHub pull
  request status box above the "Merge pull request" button.
- [x] The CHANGELOG has been updated with the planned version number.
- [x] Setup instructions have been provided.
- [x] Test instructions have been provided.
- [x] Cleanup instructions have been provided.
- [x] At least two reviewers have been requested to review this pull request.

## Self/Peer Review Checklist ([Coding Guidelines](https://docs.google.com/document/d/1h1hxQGrqnQqo1pAxrrtX1OtjHddRTqtgsgDFSXOQpzk/edit?usp=sharing))
- Meaningful variable and function names
- File header comments
- Function comments
- In-line comments summarize logical sections of code by concisely explaining
  why, not what the code is doing.  Avoid excessive or redundant commenting.
- Confirm that the automated tests pass.
- Confirm the code performs the intended functionality

## Setup
<!-- How to setup the project before testing the functionality? -->
This is just a documentation change.

## Test
<!-- How to test the functionality? -->
This is just a documentation change.

## Cleanup
This is just a documentation change.